### PR TITLE
feat: add Plex Library "Label" collection type

### DIFF
--- a/agregarr-api.yml
+++ b/agregarr-api.yml
@@ -8002,6 +8002,7 @@ paths:
                             sonarrtag,
                             comingsoon,
                             filtered_hub,
+                            plex,
                           ]
                         example: 'imdb'
                       subtype:
@@ -16095,10 +16096,18 @@ paths:
 
   /plex/labels:
     get:
-      summary: Get all Plex labels
-      description: Fetches all unique labels (tags) from all movie and TV show libraries in Plex. Used for the Plex Label condition field in overlay templates.
+      summary: Get Plex labels
+      description: Fetches unique labels (tags) from Plex. With no query parameter, aggregates labels across all movie and TV show libraries (used for the Plex Label condition field in overlay templates). With `libraryId`, returns only the labels present in that single library (used by the Plex Library "Label" collection type).
       tags:
         - overlays
+      parameters:
+        - name: libraryId
+          in: query
+          required: false
+          description: Restrict results to a single library, by section key. Omit to aggregate across all movie/TV libraries.
+          schema:
+            type: string
+          example: '10'
       responses:
         '200':
           description: Unique labels across all libraries

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -3547,6 +3547,71 @@ class PlexAPI {
   }
 
   /**
+   * Get all library items that carry a specific label (movies or TV).
+   * Pages through the full result set so the entire labelled subset is returned.
+   */
+  public async getItemsByLabel(
+    libraryId: string,
+    label: string,
+    mediaType: 'movie' | 'tv'
+  ): Promise<PlexLibraryItem[]> {
+    const type = mediaType === 'movie' ? 1 : 2;
+    const labelFilter = encodeURIComponent(label);
+    // Exclude Agregarr's own placeholder items so they never leak into a label collection.
+    const placeholderFilter = encodeURIComponent('trailer-placeholder');
+    const pageSize = 200;
+    const items: PlexLibraryItem[] = [];
+
+    try {
+      for (let offset = 0; ; offset += pageSize) {
+        const response = await this.plexClient.query<{
+          MediaContainer: {
+            totalSize?: number;
+            size?: number;
+            Metadata?: PlexLibraryItem[];
+          };
+        }>({
+          uri: `/library/sections/${libraryId}/all?type=${type}&label=${labelFilter}&label!=${placeholderFilter}&includeGuids=1`,
+          extraHeaders: {
+            'X-Plex-Container-Start': `${offset}`,
+            'X-Plex-Container-Size': `${pageSize}`,
+          },
+        });
+
+        const batch = response.MediaContainer.Metadata || [];
+        items.push(...batch);
+
+        const total =
+          response.MediaContainer.totalSize ??
+          response.MediaContainer.size ??
+          batch.length;
+        if (batch.length < pageSize || items.length >= total) {
+          break;
+        }
+      }
+
+      logger.debug(
+        `Found ${items.length} items with label "${label}" in library ${libraryId}`,
+        { label: 'Plex API', plexLabel: label, libraryId, mediaType }
+      );
+
+      return items;
+    } catch (error) {
+      logger.error(
+        `Failed to fetch items for label "${label}" in library ${libraryId}`,
+        {
+          label: 'Plex API',
+          plexLabel: label,
+          libraryId,
+          mediaType,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Get all labels for a library
    * @param libraryId - Library section key
    * @returns Array of unique label names

--- a/server/lib/collections/core/types.ts
+++ b/server/lib/collections/core/types.ts
@@ -681,6 +681,17 @@ export interface SonarrTagSourceData {
 }
 
 /**
+ * Plex Library label source data (items in a library carrying a given Plex
+ * label). Carries only the fields the label collection maps into CollectionItems.
+ */
+export interface PlexLabelSourceData {
+  ratingKey: string;
+  title: string;
+  year?: number;
+  Guid?: { id: string }[];
+}
+
+/**
  * Placeholder source data (for createPlaceholdersForMissing feature)
  * Used by any collection type that supports placeholder creation
  */
@@ -741,6 +752,7 @@ export type CollectionSourceData =
   | MyAnimeListSourceData
   | RadarrTagSourceData
   | SonarrTagSourceData
+  | PlexLabelSourceData
   | PlaceholderSourceData
   | RecentlyAddedSourceData;
 

--- a/server/lib/collections/sources/plexlibrary.ts
+++ b/server/lib/collections/sources/plexlibrary.ts
@@ -6,12 +6,13 @@ import { PosterTemplate } from '@server/entity/PosterTemplate';
  * Creates smart collections based on Plex library metadata (e.g., directors, actors).
  */
 
-import type PlexAPI from '@server/api/plexapi';
+import PlexAPI from '@server/api/plexapi';
 import TheMovieDb from '@server/api/themoviedb';
 import { BaseCollectionSync } from '@server/lib/collections/core/BaseCollectionSync';
 import {
   extractTmdbIdFromGuids,
   extractTvdbIdFromGuids,
+  getAdminUser,
   getCollectionMediaType,
   hasAgregarrLabel,
   type LibraryItemsCache,
@@ -26,6 +27,7 @@ import type {
   MissingItem,
   PlexCollection,
   PlexLabel,
+  PlexLabelSourceData,
   SyncResult,
 } from '@server/lib/collections/core/types';
 import { CollectionSyncErrorType } from '@server/lib/collections/core/types';
@@ -731,6 +733,18 @@ export class PlexLibraryCollectionSync extends BaseCollectionSync<'plex'> {
     _mediaType: 'movie' | 'tv'
   ): Promise<Record<string, unknown>> {
     void _mediaType;
+
+    // Label collections are a single collection named by the config, not per-person.
+    if (config.subtype === 'label') {
+      return {
+        source: 'plex',
+        subtype: 'label',
+        plexLabel: config.plexLabel,
+        name: config.name,
+        collectionName: config.name,
+      };
+    }
+
     const personPlaceholder =
       config.subtype === 'actors' ? '{actor}' : '{director}';
 
@@ -1046,20 +1060,76 @@ export class PlexLibraryCollectionSync extends BaseCollectionSync<'plex'> {
   }
 
   public override async fetchSourceData(
-    _config: CollectionConfig,
+    config: CollectionConfig,
     _options?: CollectionSyncOptions,
     _libraryCache?: LibraryItemsCache
   ): Promise<CollectionSourceData[]> {
-    void _config;
     void _options;
     void _libraryCache;
-    // Director collections use Plex library data gathered during processing; no external source fetch required.
-    return [];
+    // Only the 'label' subtype uses the standard fetch/map pipeline (e.g. for the
+    // collection Preview). Director/actor/separator collections build their items
+    // during processConfiguration and need no external source fetch.
+    if (config.subtype !== 'label') {
+      return [];
+    }
+    const plexLabel = config.plexLabel?.trim();
+    if (!plexLabel || !config.libraryId) {
+      return [];
+    }
+    const admin = await getAdminUser();
+    if (!admin?.plexToken) {
+      return [];
+    }
+    const plexClient = new PlexAPI({ plexToken: admin.plexToken });
+    const mediaType = getCollectionMediaType(config);
+    const plexItems = await plexClient.getItemsByLabel(
+      config.libraryId,
+      plexLabel,
+      mediaType
+    );
+    // Return the minimal source-data shape. PlexLabelSourceData is a member of
+    // the CollectionSourceData union, so this needs no cast.
+    return plexItems.map(
+      (item): PlexLabelSourceData => ({
+        ratingKey: item.ratingKey,
+        title: item.title,
+        year: item.year,
+        Guid: item.Guid,
+      })
+    );
+  }
+
+  /**
+   * Map Plex library items (label source data) to CollectionItems. Shared by the
+   * sync path (processLabelConfiguration) and the Preview path
+   * (mapSourceDataToItems) so the two can't drift.
+   */
+  private mapPlexItemsToCollectionItems(
+    items: PlexLabelSourceData[],
+    config: CollectionConfig
+  ): CollectionItem[] {
+    const mediaType = getCollectionMediaType(config);
+    return items.map((item, index) => {
+      const tmdbId = extractTmdbIdFromGuids(item.Guid);
+      const tvdbId = extractTvdbIdFromGuids(item.Guid);
+      return {
+        ratingKey: item.ratingKey,
+        title: item.title,
+        type: mediaType === 'movie' ? 'movie' : 'tv',
+        year: item.year,
+        tmdbId: tmdbId ?? undefined,
+        tvdbId: tvdbId ?? undefined,
+        metadata: {
+          libraryKey: config.libraryId,
+          originalPosition: index + 1, // Preserve source order for multi-source interleaving
+        },
+      } as CollectionItem;
+    });
   }
 
   public override async mapSourceDataToItems(
-    _sourceData: CollectionSourceData[],
-    _config: CollectionConfig,
+    sourceData: CollectionSourceData[],
+    config: CollectionConfig,
     _plexClient?: PlexAPI,
     _libraryCache?: LibraryItemsCache
   ): Promise<{
@@ -1067,15 +1137,27 @@ export class PlexLibraryCollectionSync extends BaseCollectionSync<'plex'> {
     missingItems?: MissingItem[];
     stats?: FilteringStats;
   }> {
-    void _sourceData;
-    void _config;
     void _plexClient;
     void _libraryCache;
-    // Items are derived directly from Plex during processConfiguration.
+    // Non-label plex collections derive their items during processConfiguration.
+    if (config.subtype !== 'label') {
+      return {
+        items: [],
+        missingItems: [],
+        stats: { original: 0, filtered: 0, removed: 0 },
+      };
+    }
+    // Label items are already Plex library items, so they're all in-library.
+    // Narrow the union with a type guard (ratingKey is unique to label source
+    // data) so no cast is needed.
+    const labelItems = sourceData.filter(
+      (item): item is PlexLabelSourceData => 'ratingKey' in item
+    );
+    const items = this.mapPlexItemsToCollectionItems(labelItems, config);
     return {
-      items: [],
+      items,
       missingItems: [],
-      stats: { original: 0, filtered: 0, removed: 0 },
+      stats: { original: items.length, filtered: items.length, removed: 0 },
     };
   }
 
@@ -1100,6 +1182,102 @@ export class PlexLibraryCollectionSync extends BaseCollectionSync<'plex'> {
       updated: 0,
       itemCount: 0,
     };
+  }
+
+  /**
+   * Process a label collection - builds a single collection from all library
+   * items that carry the configured Plex label, then runs them through the
+   * standard filtering/ordering/creation pipeline (same as any other source).
+   */
+  private async processLabelConfiguration(
+    config: CollectionConfig,
+    plexClient: PlexAPI,
+    allCollections: PlexCollection[],
+    processedCollectionKeys?: Set<string>,
+    libraryCache?: LibraryItemsCache
+  ): Promise<SyncResult> {
+    const plexLabel = config.plexLabel?.trim();
+    if (!plexLabel) {
+      throw this.createSyncError(
+        CollectionSyncErrorType.CONFIGURATION_ERROR,
+        `No Plex label specified for collection: ${config.name}`
+      );
+    }
+    if (!config.libraryId) {
+      throw this.createSyncError(
+        CollectionSyncErrorType.CONFIGURATION_ERROR,
+        `No library specified for label collection: ${config.name}`
+      );
+    }
+
+    const mediaType = getCollectionMediaType(config);
+
+    logger.info('Processing label collection', {
+      label: 'Plex Library Collections',
+      configName: config.name,
+      libraryId: config.libraryId,
+      plexLabel,
+    });
+
+    try {
+      const plexItems = await plexClient.getItemsByLabel(
+        config.libraryId,
+        plexLabel,
+        mediaType
+      );
+
+      const items = this.mapPlexItemsToCollectionItems(plexItems, config);
+
+      const { items: filteredItems } = await this.applyFilteringToMappedItems(
+        {
+          items,
+          missingItems: [],
+          stats: {
+            original: items.length,
+            filtered: items.length,
+            removed: 0,
+          },
+        },
+        config
+      );
+
+      if (filteredItems.length === 0) {
+        logger.warn(`No items found with label "${plexLabel}"`, {
+          label: 'Plex Library Collections',
+          configName: config.name,
+          libraryId: config.libraryId,
+          plexLabel,
+        });
+        return { created: 0, updated: 0 };
+      }
+
+      return await this.processWithMediaTypeStrategy(
+        filteredItems,
+        config,
+        plexClient,
+        allCollections,
+        processedCollectionKeys,
+        undefined,
+        libraryCache,
+        []
+      );
+    } catch (error) {
+      logger.error('Failed to process label collection', {
+        label: 'Plex Library Collections',
+        configName: config.name,
+        libraryId: config.libraryId,
+        plexLabel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw this.createSyncError(
+        CollectionSyncErrorType.API_ERROR,
+        `Failed to build label collection "${
+          config.name
+        }" from label "${plexLabel}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
   }
 
   /**
@@ -1150,10 +1328,20 @@ export class PlexLibraryCollectionSync extends BaseCollectionSync<'plex'> {
       );
     }
 
+    if (subtype === 'label') {
+      return this.processLabelConfiguration(
+        config,
+        plexClient,
+        allCollections,
+        processedCollectionKeys,
+        _libraryCache
+      );
+    }
+
     if (!subtype || (subtype !== 'directors' && subtype !== 'actors')) {
       throw this.createSyncError(
         CollectionSyncErrorType.CONFIGURATION_ERROR,
-        `Invalid plex subtype: ${subtype}. Supported: directors, actors, separator, genre, decade, resolution, contentRating.`
+        `Invalid plex subtype: ${subtype}. Supported: directors, actors, separator, label, genre, decade, resolution, contentRating.`
       );
     }
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -235,6 +235,8 @@ export interface CollectionConfig {
   readonly sonarrInstanceId?: number; // Selected Sonarr instance ID for tag-based collections
   // Generic ordering options (applicable to all collection types)
   readonly sortOrder?: CollectionSortOrder; // Sort order for collection items (default: 'default')
+  // Plex Library label subtype: build a collection from items carrying this Plex label
+  readonly plexLabel?: string;
   // Unified person minimum items (applies to both actors and directors)
   readonly personMinimumItems?: number;
   // Plex Library separator settings for auto person collections

--- a/server/routes/collections-preview.ts
+++ b/server/routes/collections-preview.ts
@@ -941,6 +941,7 @@ async function processPreviewAsync(
     sonarrTagId?: number;
     radarrInstanceId?: number;
     sonarrInstanceId?: number;
+    plexLabel?: string;
     // Coming Soon specific fields
     comingSoonRadarrServerId?: number;
     comingSoonSonarrServerId?: number;
@@ -988,6 +989,7 @@ async function processPreviewAsync(
       radarrInstanceId,
       sonarrTagId,
       sonarrInstanceId,
+      plexLabel,
       comingSoonRadarrServerId,
       comingSoonSonarrServerId,
       comingSoonRadarrRootFolder,
@@ -1092,6 +1094,10 @@ async function processPreviewAsync(
     if (type === 'sonarrtag') {
       previewConfigRecord.sonarrTagId = sonarrTagId;
       previewConfigRecord.sonarrInstanceId = sonarrInstanceId;
+    }
+
+    if (type === 'plex') {
+      previewConfigRecord.plexLabel = plexLabel;
     }
 
     if (type === 'tautulli') {

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -209,11 +209,12 @@ searchRouter.get('/search', async (req, res) => {
 });
 
 /**
- * Get all unique labels across all movie/show libraries
- * GET /api/v1/plex/labels
+ * Get unique Plex labels.
+ * GET /api/v1/plex/labels            -> labels across all movie/show libraries
+ * GET /api/v1/plex/labels?libraryId= -> labels in a single library only
  * Returns: { labels: string[] }
  */
-searchRouter.get('/labels', async (_req, res) => {
+searchRouter.get('/labels', async (req, res) => {
   try {
     // Get admin user for Plex API access
     const { getAdminUser } = await import(
@@ -230,9 +231,13 @@ searchRouter.get('/labels', async (_req, res) => {
     // Get all libraries
     const allLibraries = await plexApi.getLibraries();
 
-    // Filter to only movie and show libraries
+    // Filter to only movie and show libraries, optionally to a single library
+    const libraryId =
+      typeof req.query.libraryId === 'string' ? req.query.libraryId : undefined;
     const libraries = allLibraries.filter(
-      (lib) => lib.type === 'movie' || lib.type === 'show'
+      (lib) =>
+        (lib.type === 'movie' || lib.type === 'show') &&
+        (!libraryId || lib.key === libraryId)
     );
 
     // Fetch labels for each library and collect unique ones

--- a/src/components/Collections/FormSections/CollectionTypeSection.tsx
+++ b/src/components/Collections/FormSections/CollectionTypeSection.tsx
@@ -377,6 +377,12 @@ const CollectionTypeSection = ({
               'Automatically create smart collections for the top 5 actors in this library.',
           },
           {
+            value: 'label',
+            label: 'Label',
+            description:
+              'Build a collection from every item in this library that has a specific Plex label.',
+          },
+          {
             value: 'separator',
             label: 'Separator',
             description:

--- a/src/components/Collections/FormSections/PlexLabelSection.tsx
+++ b/src/components/Collections/FormSections/PlexLabelSection.tsx
@@ -1,0 +1,90 @@
+import type { CollectionFormConfig } from '@app/types/collections';
+import type React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import useSWR from 'swr';
+
+const messages = defineMessages({
+  plexLabel: 'Plex Label',
+  selectLabel: 'Select label...',
+  selectLibraryFirst: 'Select a library above first',
+  loadingLabels: 'Loading labels...',
+  noLabelsFound: 'No labels found in this library',
+  plexLabelHelp:
+    'Only items in the selected library that carry this label are included. Membership refreshes on each sync.',
+});
+
+interface PlexLabelSectionProps {
+  values: CollectionFormConfig;
+  setFieldValue: (
+    field: string,
+    value: string | number | boolean | string[] | object | undefined
+  ) => void;
+  isVisible?: boolean;
+}
+
+const PlexLabelSection = ({
+  values,
+  setFieldValue,
+  isVisible = true,
+}: PlexLabelSectionProps) => {
+  const intl = useIntl();
+
+  const selectedLibraryId =
+    (Array.isArray(values.libraryIds) && values.libraryIds[0]) ||
+    values.libraryId ||
+    '';
+
+  const { data: plexLabelsData, error: plexLabelsError } = useSWR<{
+    labels: string[];
+  }>(
+    isVisible && selectedLibraryId
+      ? `/api/v1/plex/labels?libraryId=${encodeURIComponent(selectedLibraryId)}`
+      : null
+  );
+
+  if (!isVisible) return null;
+
+  return (
+    <div>
+      <label htmlFor="plexLabel" className="mb-2 block text-sm text-gray-300">
+        {intl.formatMessage(messages.plexLabel)}{' '}
+        <span className="text-red-500">*</span>
+      </label>
+      <select
+        id="plexLabel"
+        name="plexLabel"
+        className="w-full rounded-md border border-stone-500 bg-stone-700 px-3 py-2 text-white focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        value={values.plexLabel || ''}
+        disabled={!selectedLibraryId || (!plexLabelsData && !plexLabelsError)}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+          setFieldValue('plexLabel', e.target.value || undefined)
+        }
+      >
+        <option value="">
+          {!selectedLibraryId
+            ? intl.formatMessage(messages.selectLibraryFirst)
+            : !plexLabelsData && !plexLabelsError
+            ? intl.formatMessage(messages.loadingLabels)
+            : intl.formatMessage(messages.selectLabel)}
+        </option>
+        {plexLabelsData?.labels?.map((label) => (
+          <option key={label} value={label}>
+            {label}
+          </option>
+        ))}
+      </select>
+      {selectedLibraryId &&
+        plexLabelsData &&
+        plexLabelsData.labels.length === 0 && (
+          <p className="mt-1 text-xs text-amber-400">
+            {intl.formatMessage(messages.noLabelsFound)}
+          </p>
+        )}
+      <p className="mt-1 text-xs text-gray-400">
+        {intl.formatMessage(messages.plexLabelHelp)}
+      </p>
+    </div>
+  );
+};
+
+export default PlexLabelSection;

--- a/src/components/Collections/Forms/CollectionConfigForm.tsx
+++ b/src/components/Collections/Forms/CollectionConfigForm.tsx
@@ -39,6 +39,7 @@ import LibrarySelectionSection from '@app/components/Collections/FormSections/Li
 import MultiSourceConfigSection from '@app/components/Collections/FormSections/MultiSourceConfigSection';
 import NetworksConfigSection from '@app/components/Collections/FormSections/NetworksConfigSection';
 import OriginalsConfigSection from '@app/components/Collections/FormSections/OriginalsConfigSection';
+import PlexLabelSection from '@app/components/Collections/FormSections/PlexLabelSection';
 import PosterUploadSection from '@app/components/Collections/FormSections/PosterUploadSection';
 import TemplateSection from '@app/components/Collections/FormSections/TemplateSection';
 import ThemeUploadSection from '@app/components/Collections/FormSections/ThemeUploadSection';
@@ -119,6 +120,7 @@ const messages = defineMessages({
   validationPersonMinimumItemsMin: 'Minimum items must be at least 2',
   validationSeparatorTitleRequired: 'Separator title is required',
   validationSeparatorTitleMin: 'Separator title must be at least 2 characters',
+  validationPlexLabelRequired: 'Please select a Plex label',
   validationLibraryMin: 'Please select at least one library',
   validationLibraryRequired: 'Please select at least one library',
   validationRadarrInstanceRequired: 'Radarr instance is required',
@@ -584,6 +586,17 @@ const CollectionFormConfigForm = ({
               intl.formatMessage(messages.validationSeparatorTitleRequired)
             )
             .min(2, intl.formatMessage(messages.validationSeparatorTitleMin)),
+        otherwise: (schema) => schema.notRequired(),
+      }),
+    plexLabel: Yup.string()
+      .transform((value) => value?.trim())
+      .when(['type', 'subtype'], {
+        is: (type?: string, subtype?: string) =>
+          type === 'plex' && subtype === 'label',
+        then: (schema) =>
+          schema.required(
+            intl.formatMessage(messages.validationPlexLabelRequired)
+          ),
         otherwise: (schema) => schema.notRequired(),
       }),
 
@@ -1748,6 +1761,7 @@ const CollectionFormConfigForm = ({
             (config as CollectionFormConfig).radarrTagId ?? undefined,
           sonarrTagId:
             (config as CollectionFormConfig).sonarrTagId ?? undefined,
+          plexLabel: (config as CollectionFormConfig).plexLabel ?? undefined,
           // Coming Soon monitored server/tag filtering
           comingSoonRadarrServerId:
             (config as CollectionFormConfig).comingSoonRadarrServerId ??
@@ -3026,6 +3040,18 @@ const CollectionFormConfigForm = ({
                         isEssentialsRender &&
                         (values.libraryIds?.length > 0 || values.libraryId) && (
                           <LibraryEssentialsPreview />
+                        )}
+
+                      {/* Plex Label picker - rendered after library selection so a
+                          library is chosen before its labels are fetched */}
+                      {isCollection &&
+                        values.type === 'plex' &&
+                        values.subtype === 'label' && (
+                          <PlexLabelSection
+                            values={typedValues as CollectionFormConfig}
+                            setFieldValue={setFieldValue}
+                            isVisible={true}
+                          />
                         )}
 
                       {/* Regular Form - show full form for normal collections */}
@@ -5237,6 +5263,7 @@ const CollectionFormConfigForm = ({
                         sonarrTagId: values.sonarrTagId,
                         radarrInstanceId: values.radarrInstanceId,
                         sonarrInstanceId: values.sonarrInstanceId,
+                        plexLabel: values.plexLabel,
                         // Coming Soon specific fields
                         comingSoonRadarrServerId:
                           values.comingSoonRadarrServerId,

--- a/src/components/Collections/PreviewCollectionModal/index.tsx
+++ b/src/components/Collections/PreviewCollectionModal/index.tsx
@@ -102,6 +102,7 @@ interface PreviewCollectionModalProps {
     sonarrTagId?: number;
     radarrInstanceId?: number;
     sonarrInstanceId?: number;
+    plexLabel?: string;
     // Coming Soon specific fields
     comingSoonRadarrServerId?: number;
     comingSoonSonarrServerId?: number;
@@ -229,6 +230,7 @@ const PreviewCollectionModal = ({
     sonarrTagId: previewConfig.sonarrTagId,
     radarrInstanceId: previewConfig.radarrInstanceId,
     sonarrInstanceId: previewConfig.sonarrInstanceId,
+    plexLabel: previewConfig.plexLabel,
     comingSoonRadarrServerId: previewConfig.comingSoonRadarrServerId,
     comingSoonSonarrServerId: previewConfig.comingSoonSonarrServerId,
     comingSoonRadarrRootFolder: previewConfig.comingSoonRadarrRootFolder,
@@ -315,6 +317,7 @@ const PreviewCollectionModal = ({
           sonarrTagId: previewConfig.sonarrTagId,
           radarrInstanceId: previewConfig.radarrInstanceId,
           sonarrInstanceId: previewConfig.sonarrInstanceId,
+          plexLabel: previewConfig.plexLabel,
           // Coming Soon specific fields
           comingSoonRadarrServerId: previewConfig.comingSoonRadarrServerId,
           comingSoonSonarrServerId: previewConfig.comingSoonSonarrServerId,

--- a/src/types/collections/index.ts
+++ b/src/types/collections/index.ts
@@ -428,6 +428,8 @@ export interface CollectionFormConfig {
   readonly comingSoonSonarrRootFolder?: string; // Sonarr root folder path to filter by
   // Generic ordering options (applicable to all collection types)
   readonly sortOrder?: CollectionSortOrder; // Sort order for collection items (default: 'default')
+  // Plex Library label subtype: build a collection from items carrying this Plex label
+  readonly plexLabel?: string;
   // Unified person minimum items for plex/actors|directors
   readonly personMinimumItems?: number;
   // Plex Library separator settings for multi-collections (actors/directors)
@@ -641,6 +643,8 @@ export interface CollectionConfigCreateRequest {
   readonly comingSoonRadarrRootFolder?: string;
   readonly comingSoonSonarrRootFolder?: string;
   readonly sortOrder?: CollectionSortOrder;
+  // Plex Library label subtype: build a collection from items carrying this Plex label
+  readonly plexLabel?: string;
   // Unified person minimum items for plex actors/directors
   readonly personMinimumItems?: number;
   // Plex Library separator settings for auto person multi-collections


### PR DESCRIPTION
## What this adds

A **Label** sub-type under the **Plex Library** collection type that builds a
collection from every item in a library carrying a given Plex label.

It mirrors the existing **Radarr/Sonarr Tag** pattern: the labelled items are
fetched from Plex and run through the standard filter → order → create pipeline,
so a Label collection behaves like any other collection — overlays, generated
posters, ordering, visibility, the unwatched smart-collection toggle, and
cleanup all work with no special-casing.

## Changes

**Server**
- `getItemsByLabel()` on the Plex API (paged; excludes `trailer-placeholder` items)
- A `label` branch in the Plex Library source that builds the collection through the standard pipeline
- `plexLabel` on the collection config
- Optional `libraryId` query param on `GET /plex/labels` to list a single library's labels

**UI**
- A **Label** sub-type option under Plex Library
- A `PlexLabelSection` dropdown (populated with the selected library's labels), shown after library selection, with required-field validation

**Preview**
- The Plex source's `fetchSourceData` / `mapSourceDataToItems` handle the `label` subtype so the collection **Preview** lists the labelled items (read-only — no writes to Plex)
- `plex` added to the preview `sources[].type` enum

## Testing

Tested locally against a real Plex movie library: creating a Label collection
populates it with exactly the items carrying the chosen label, and Preview lists
them with posters (marked in-library). Server + client typecheck and lint clean.

## A note on placement

I slotted this as a sub-type under **Plex Library**, since the items come
straight from the Plex library. If you feel it belongs somewhere else (a
different collection type, or its own top-level type), please feel free to move
it — or let me know and I'll adjust.
