### PR TITLE
feat(overlays): all-seasons option for show-level Maintainerr countdown

### DIFF
--- a/server/entity/OverlayLibraryConfig.ts
+++ b/server/entity/OverlayLibraryConfig.ts
@@ -48,10 +48,16 @@ export class OverlayLibraryConfig {
   @Column({ type: 'boolean', default: false })
   public enableMaintainerrSeasonOverlays: boolean;
 
-  // Sub-toggle of enableMaintainerrSeasonOverlays: hold the show poster's
-  // countdown back until every season of the show is scheduled to leave.
+  // "Show poster countdown": hold the show poster's countdown back until every
+  // season of the show is scheduled to leave. Independent of
+  // enableMaintainerrSeasonOverlays, which governs the season posters.
   @Column({ type: 'boolean', default: false })
   public requireAllSeasonsLeaving: boolean;
+
+  // Only consulted when requireAllSeasonsLeaving is on: date the show by the
+  // last season to leave (true) or the first (false).
+  @Column({ type: 'boolean', default: true })
+  public useLatestSeasonDate: boolean;
 
   @CreateDateColumn()
   public createdAt: Date;

--- a/server/entity/OverlayLibraryConfig.ts
+++ b/server/entity/OverlayLibraryConfig.ts
@@ -48,6 +48,11 @@ export class OverlayLibraryConfig {
   @Column({ type: 'boolean', default: false })
   public enableMaintainerrSeasonOverlays: boolean;
 
+  // Sub-toggle of enableMaintainerrSeasonOverlays: hold the show poster's
+  // countdown back until every season of the show is scheduled to leave.
+  @Column({ type: 'boolean', default: false })
+  public requireAllSeasonsLeaving: boolean;
+
   @CreateDateColumn()
   public createdAt: Date;
 

--- a/server/lib/overlays/OverlayContextBuilder.ts
+++ b/server/lib/overlays/OverlayContextBuilder.ts
@@ -20,6 +20,7 @@ import {
 } from '@server/utils/dateHelpers';
 import { getAdaptiveTtl, getNullRatingTtl } from './adaptiveTtl';
 import { hasStreamingProviderIcon } from './DefaultMappingsService';
+import type { SeasonFallbackMode } from './maintainerrCountdown';
 import { computeDaysUntilAction } from './maintainerrCountdown';
 import type { OverlayRenderContext } from './OverlayTemplateRenderer';
 
@@ -239,6 +240,10 @@ const rtInflightRequests = new Map<string, Promise<RTRating | null>>();
  * @param preloadedImdbRatings - Optional pre-fetched IMDb ratings map (imdbId -> rating | null)
  *                               When provided, skips individual IMDb API calls for items in the map.
  *                               null means "checked, no rating available" (avoids redundant API calls).
+ * @param seasonFallback - Whether a show with no Maintainerr schedule of its own may
+ *                         inherit one from its seasons, per the library's season-countdown
+ *                         toggles. Defaults to 'off': a caller that has not read the config
+ *                         cannot put a season's deletion date on a show poster.
  * @returns Object containing the context and a flag indicating if critical APIs failed.
  *          When criticalApiFailed is true, callers should skip overlay application
  *          to avoid regenerating posters with incomplete data.
@@ -279,7 +284,8 @@ export async function buildRenderContext(
   isPlaceholder = false,
   maintainerrCollections?: MaintainerrCollection[],
   preloadedImdbRatings?: Map<string, number | null>,
-  requiredContextFields?: Set<string>
+  requiredContextFields?: Set<string>,
+  seasonFallback: SeasonFallbackMode = 'off'
 ): Promise<BuildRenderContextResult> {
   // Track if critical APIs failed (IMDb rating is critical for rating overlays)
   let criticalApiFailed = false;
@@ -1111,7 +1117,16 @@ export async function buildRenderContext(
       const selected = computeDaysUntilAction(
         maintainerrCollections,
         item.ratingKey,
-        { mediaType, tmdbId }
+        {
+          mediaType,
+          tmdbId,
+          seasonFallback,
+          // Plex counts Specials in childCount, which is what 'all' needs: the
+          // show only leaves once every season including season 0 does. Read
+          // from the item itself so it cannot disagree with seasonsAvailable.
+          // Absent on a season item, where 'all' has no meaning anyway.
+          totalSeasons: item.type === 'show' ? item.childCount : undefined,
+        }
       );
 
       if (selected) {

--- a/server/lib/overlays/OverlayContextBuilder.ts
+++ b/server/lib/overlays/OverlayContextBuilder.ts
@@ -20,8 +20,11 @@ import {
 } from '@server/utils/dateHelpers';
 import { getAdaptiveTtl, getNullRatingTtl } from './adaptiveTtl';
 import { hasStreamingProviderIcon } from './DefaultMappingsService';
-import type { SeasonFallbackMode } from './maintainerrCountdown';
-import { computeDaysUntilAction } from './maintainerrCountdown';
+import type { SeasonFallback } from './maintainerrCountdown';
+import {
+  computeDaysUntilAction,
+  NO_SEASON_FALLBACK,
+} from './maintainerrCountdown';
 import type { OverlayRenderContext } from './OverlayTemplateRenderer';
 
 // Captured defensively: the app replaces the global Intl with the andyearnshaw
@@ -241,9 +244,10 @@ const rtInflightRequests = new Map<string, Promise<RTRating | null>>();
  *                               When provided, skips individual IMDb API calls for items in the map.
  *                               null means "checked, no rating available" (avoids redundant API calls).
  * @param seasonFallback - Whether a show with no Maintainerr schedule of its own may
- *                         inherit one from its seasons, per the library's season-countdown
- *                         toggles. Defaults to 'off': a caller that has not read the config
- *                         cannot put a season's deletion date on a show poster.
+ *                         inherit one from its seasons, and which season's date it takes,
+ *                         per the library's "Show poster countdown" setting. Defaults to
+ *                         NO_SEASON_FALLBACK: a caller that has not read the config cannot
+ *                         put a season's deletion date on a show poster.
  * @returns Object containing the context and a flag indicating if critical APIs failed.
  *          When criticalApiFailed is true, callers should skip overlay application
  *          to avoid regenerating posters with incomplete data.
@@ -285,7 +289,7 @@ export async function buildRenderContext(
   maintainerrCollections?: MaintainerrCollection[],
   preloadedImdbRatings?: Map<string, number | null>,
   requiredContextFields?: Set<string>,
-  seasonFallback: SeasonFallbackMode = 'off'
+  seasonFallback: SeasonFallback = NO_SEASON_FALLBACK
 ): Promise<BuildRenderContextResult> {
   // Track if critical APIs failed (IMDb rating is critical for rating overlays)
   let criticalApiFailed = false;

--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -29,8 +29,8 @@ import type {
 import {
   collectSeasonCandidateKeys,
   computeDaysUntilAction,
-  seasonFallbackModeFor,
-  type SeasonFallbackMode,
+  seasonFallbackFor,
+  type SeasonFallback,
 } from './maintainerrCountdown';
 import {
   buildRenderContext,
@@ -1667,7 +1667,7 @@ class OverlayLibraryService {
             libraryId,
             config.libraryName,
             maintainerrCollections,
-            seasonFallbackModeFor(config)
+            seasonFallbackFor(config)
           );
 
           // Update counts AFTER outcome is known
@@ -2012,7 +2012,7 @@ class OverlayLibraryService {
                 // read whatever a concurrent library job left in the shared cache.
                 undefined,
                 // Moot without collections, but kept honest to the config.
-                seasonFallbackModeFor(config),
+                seasonFallbackFor(config),
                 contextOverrides,
                 aggregatedMedia
               );
@@ -2053,9 +2053,10 @@ class OverlayLibraryService {
    * will use item.type for TMDB API calls to prevent fetching wrong posters
    *
    * @param seasonFallback - Whether a show with no Maintainerr schedule of its own
-   *   may inherit one from its seasons. Derived from the library config by every
-   *   caller (see `seasonFallbackModeFor`) so the two season-countdown toggles reach
-   *   the countdown; 'off' is the safe default for a caller with no config to hand.
+   *   may inherit one from its seasons, and which season's date it takes. Derived
+   *   from the library config by every caller (see `seasonFallbackFor`) so the
+   *   "Show poster countdown" setting reaches the countdown by one route;
+   *   NO_SEASON_FALLBACK is the safe value for a caller with no config to hand.
    * @param requireOverlayMatch - When true, an item whose conditions match no
    *   template is skipped before any poster work. Callers that visit items only
    *   because an external source nominated them (the Maintainerr season subpass)
@@ -2071,7 +2072,7 @@ class OverlayLibraryService {
     libraryId: string,
     libraryName: string,
     maintainerrCollections: MaintainerrCollection[] | undefined,
-    seasonFallback: SeasonFallbackMode,
+    seasonFallback: SeasonFallback,
     contextOverrides?: Partial<OverlayRenderContext>,
     aggregatedMediaOverride?: Map<string, AggregatedMediaInfo>,
     requireOverlayMatch?: boolean
@@ -2921,8 +2922,8 @@ class OverlayLibraryService {
           config.libraryName,
           collections,
           // A season is matched by its own ratingKey, never by the show-level
-          // fallback, so the mode only has to be honest rather than special.
-          seasonFallbackModeFor(config),
+          // fallback, so the setting only has to be honest rather than special.
+          seasonFallbackFor(config),
           // buildRenderContext reads a show item's `index` as an episode number.
           // Correct both fields here rather than withholding `index` from the item,
           // so the context says what a season actually is. `episodeNumber` must be

--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -29,6 +29,8 @@ import type {
 import {
   collectSeasonCandidateKeys,
   computeDaysUntilAction,
+  seasonFallbackModeFor,
+  type SeasonFallbackMode,
 } from './maintainerrCountdown';
 import {
   buildRenderContext,
@@ -1664,7 +1666,8 @@ class OverlayLibraryService {
             config.mediaType,
             libraryId,
             config.libraryName,
-            maintainerrCollections
+            maintainerrCollections,
+            seasonFallbackModeFor(config)
           );
 
           // Update counts AFTER outcome is known
@@ -2008,6 +2011,8 @@ class OverlayLibraryService {
                 // undefined removes the old cross-job contamination where it
                 // read whatever a concurrent library job left in the shared cache.
                 undefined,
+                // Moot without collections, but kept honest to the config.
+                seasonFallbackModeFor(config),
                 contextOverrides,
                 aggregatedMedia
               );
@@ -2047,6 +2052,10 @@ class OverlayLibraryService {
    * NOTE: configuredLibraryType is the library's configured type, but PlexBasePosterManager
    * will use item.type for TMDB API calls to prevent fetching wrong posters
    *
+   * @param seasonFallback - Whether a show with no Maintainerr schedule of its own
+   *   may inherit one from its seasons. Derived from the library config by every
+   *   caller (see `seasonFallbackModeFor`) so the two season-countdown toggles reach
+   *   the countdown; 'off' is the safe default for a caller with no config to hand.
    * @param requireOverlayMatch - When true, an item whose conditions match no
    *   template is skipped before any poster work. Callers that visit items only
    *   because an external source nominated them (the Maintainerr season subpass)
@@ -2062,6 +2071,7 @@ class OverlayLibraryService {
     libraryId: string,
     libraryName: string,
     maintainerrCollections: MaintainerrCollection[] | undefined,
+    seasonFallback: SeasonFallbackMode,
     contextOverrides?: Partial<OverlayRenderContext>,
     aggregatedMediaOverride?: Map<string, AggregatedMediaInfo>,
     requireOverlayMatch?: boolean
@@ -2150,7 +2160,8 @@ class OverlayLibraryService {
         isPlaceholder,
         maintainerrCollections,
         this.preloadedImdbRatings,
-        this.requiredContextFieldsByLibrary.get(libraryId)
+        this.requiredContextFieldsByLibrary.get(libraryId),
+        seasonFallback
       );
 
       // If critical APIs failed (e.g., IMDb timeout), skip this item to avoid
@@ -2909,6 +2920,9 @@ class OverlayLibraryService {
           libraryId,
           config.libraryName,
           collections,
+          // A season is matched by its own ratingKey, never by the show-level
+          // fallback, so the mode only has to be honest rather than special.
+          seasonFallbackModeFor(config),
           // buildRenderContext reads a show item's `index` as an episode number.
           // Correct both fields here rather than withholding `index` from the item,
           // so the context says what a season actually is. `episodeNumber` must be

--- a/server/lib/overlays/maintainerrCountdown.test.ts
+++ b/server/lib/overlays/maintainerrCountdown.test.ts
@@ -7,7 +7,7 @@ import {
   collectSeasonCandidateKeys,
   computeDaysUntilAction,
   hasDeletionSchedule,
-  seasonFallbackModeFor,
+  seasonFallbackFor,
 } from './maintainerrCountdown';
 
 /**
@@ -173,7 +173,8 @@ describe('computeDaysUntilAction', () => {
  * What makes this worth locking down is that the modes disagree on purpose. `'any'`
  * says "a season is going" and dates the poster by the first departure; `'all'`
  * says "the show is going" and will not commit unless it can prove every season is
- * scheduled, dating the poster by the last one. Every unprovable case in `'all'` -
+ * scheduled, dating the poster by the season that goes last or the one that goes
+ * first, whichever the library asked for. Every unprovable case in `'all'` -
  * a season staying, a row it cannot attribute to a season, a count that does not
  * line up with Plex - has to come back null, because a wrong date here tells a user
  * a show is leaving when it is not.
@@ -198,10 +199,18 @@ describe('computeDaysUntilAction show-level season fallback', () => {
   });
 
   function forShow(
-    seasonFallback: 'off' | 'any' | 'all',
-    totalSeasons?: number
+    mode: 'off' | 'any' | 'all',
+    totalSeasons?: number,
+    // The engine's own default. Spelled out here so an earliest-mode case reads
+    // as a deliberate choice rather than an omission.
+    useLatestSeasonDate = true
   ) {
-    return { mediaType: 'show', tmdbId: 100, seasonFallback, totalSeasons };
+    return {
+      mediaType: 'show',
+      tmdbId: 100,
+      seasonFallback: { mode, useLatestSeasonDate },
+      totalSeasons,
+    };
   }
 
   it("takes nothing from the seasons in 'off' mode", () => {
@@ -250,6 +259,33 @@ describe('computeDaysUntilAction show-level season fallback', () => {
     expect(result?.childItemsMatched).toBe(2);
   });
 
+  it("'any' lets an episode row drive the date without counting it as a season", () => {
+    const episodes = makeCollection({
+      id: 1,
+      title: 'Episodes',
+      type: 'episode',
+      deleteAfterDays: 35, // episode => 5, the soonest date on offer
+      media: [makeMedia({ mediaServerId: 'episode-1' })],
+    });
+    const seasons = makeCollection({
+      id: 2,
+      title: 'Seasons',
+      deleteAfterDays: 45, // season 1 => 15
+      media: [makeMedia(SEASON_1)],
+    });
+
+    const result = computeDaysUntilAction(
+      [seasons, episodes],
+      SHOW_KEY,
+      forShow('any')
+    );
+    expect(result?.days).toBe(5);
+    expect(result?.collection.title).toBe('Episodes');
+    // One SEASON is leaving. The episode drives the date, but counting it as a
+    // season would make `seasonsLeavingCount` lie about what it is named for.
+    expect(result?.childItemsMatched).toBe(1);
+  });
+
   it("'all' dates the show by the season that leaves LAST", () => {
     const collection = makeCollection({
       deleteAfterDays: 45, // season 1 => 15, season 2 => 25
@@ -289,6 +325,100 @@ describe('computeDaysUntilAction show-level season fallback', () => {
     expect(result?.days).toBe(15);
     expect(result?.collection.title).toBe('Slow');
     expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' dates the show by the latest season when no date preference is given", () => {
+    const collection = makeCollection({
+      deleteAfterDays: 45, // season 1 => 15, season 2 => 25
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    // Deliberately derived from a config where the flag is genuinely ABSENT: a
+    // library row written before the `useLatestSeasonDate` column existed reads
+    // as undefined, and that must mean "latest" - the behavior every
+    // all-seasons library had before the dropdown - not "earliest".
+    const result = computeDaysUntilAction([collection], SHOW_KEY, {
+      mediaType: 'show',
+      tmdbId: 100,
+      seasonFallback: seasonFallbackFor({ requireAllSeasonsLeaving: true }),
+      totalSeasons: 2,
+    });
+    expect(result?.days).toBe(25);
+    expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' earliest dates the show by the season that leaves FIRST", () => {
+    const collection = makeCollection({
+      deleteAfterDays: 45, // season 1 => 15, season 2 => 25
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    // The mirror of the latest case on identical data: this answers "when does
+    // the deletion start", so 15 rather than 25.
+    const result = computeDaysUntilAction(
+      [collection],
+      SHOW_KEY,
+      forShow('all', 2, false)
+    );
+    expect(result?.days).toBe(15);
+    expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' earliest takes each season's soonest collection, then the soonest of those", () => {
+    const slow = makeCollection({
+      id: 1,
+      title: 'Slow',
+      deleteAfterDays: 45, // season 1 => 15, season 2 => 25
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+    const fast = makeCollection({
+      id: 2,
+      title: 'Fast',
+      deleteAfterDays: 30, // season 2 => 10
+      media: [makeMedia(SEASON_2)],
+    });
+
+    // Season 2 leaves in 10 (Fast beats Slow's 25), season 1 in 15, so the first
+    // departure is season 2's. Only the per-season minimum survives into the
+    // cross-season reduce, so the winner has to be Fast, not Slow's 15.
+    const result = computeDaysUntilAction(
+      [slow, fast],
+      SHOW_KEY,
+      forShow('all', 2, false)
+    );
+    expect(result?.days).toBe(10);
+    // Asserted because a reduce that tracks days alone would report Fast's date
+    // under whichever collection it happened to be holding.
+    expect(result?.collection.title).toBe('Fast');
+    expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' earliest still stays silent while one season is unscheduled", () => {
+    const collection = makeCollection({
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    // Picking the earliest date is a presentation choice; it does not lower the
+    // bar for proving the show is leaving at all.
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('all', 3, false))
+    ).toBeNull();
+  });
+
+  it("'all' earliest still stays silent when a matched row carries no key", () => {
+    const collection = makeCollection({
+      media: [
+        makeMedia(SEASON_1),
+        makeMedia({ mediaServerId: undefined, plexId: undefined }),
+      ],
+    });
+
+    // Earliest mode is the one where an unattributable row is most tempting to
+    // shrug off - it can only ever be beaten by an earlier date, never change
+    // the answer upward. It is still a season we cannot prove is going.
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('all', 2, false))
+    ).toBeNull();
   });
 
   it("'all' stays silent while one season is unscheduled", () => {
@@ -488,53 +618,56 @@ describe('computeDaysUntilAction show-level season fallback', () => {
       computeDaysUntilAction([collection], SHOW_KEY, {
         mediaType: 'movie',
         tmdbId: 100,
-        seasonFallback: 'any',
+        seasonFallback: { mode: 'any', useLatestSeasonDate: true },
       })
     ).toBeNull();
   });
 });
 
 /**
- * The parent toggle gates the fallback and the sub-toggle only narrows it, so a
- * stored `requireAllSeasonsLeaving` must stay inert while the parent is off rather
- * than turning the fallback back on.
+ * One input, and pointedly not two: the "Season deletion countdown" toggle is not
+ * consulted here. It gates the season-poster subpass and the departed-season
+ * cleanup, and a user is entitled to want the show poster marked without every
+ * season poster being overlaid as well. Wiring that toggle back in would silently
+ * take the show countdown away from those libraries.
+ *
+ * Which leaves the show-level fallback answering to its own control, whose default
+ * - an unset config - is "Any season", develop's behavior.
  */
-describe('seasonFallbackModeFor', () => {
-  it.each([
-    [false, false],
-    [false, true],
-  ])(
-    'is off while the season countdown is off (sub-toggle %s/%s)',
-    (enableMaintainerrSeasonOverlays, requireAllSeasonsLeaving) => {
-      expect(
-        seasonFallbackModeFor({
-          enableMaintainerrSeasonOverlays,
-          requireAllSeasonsLeaving,
-        })
-      ).toBe('off');
-    }
-  );
-
-  it('is any with the season countdown on and the sub-toggle off', () => {
-    expect(
-      seasonFallbackModeFor({
-        enableMaintainerrSeasonOverlays: true,
-        requireAllSeasonsLeaving: false,
-      })
-    ).toBe('any');
+describe('seasonFallbackFor', () => {
+  it('is all when the library asks for every season', () => {
+    expect(seasonFallbackFor({ requireAllSeasonsLeaving: true }).mode).toBe(
+      'all'
+    );
   });
 
-  it('is all with both on', () => {
+  it('is any when the library does not', () => {
+    expect(seasonFallbackFor({ requireAllSeasonsLeaving: false }).mode).toBe(
+      'any'
+    );
+  });
+
+  it('is any for a config predating the columns', () => {
+    expect(seasonFallbackFor({}).mode).toBe('any');
+  });
+
+  it('reads an absent date preference as latest', () => {
+    // The column defaults to true. A row loaded before the migration ran has no
+    // value at all, and must not read as "earliest" - that would move the date
+    // on every existing all-seasons library without anyone touching a setting.
+    expect(seasonFallbackFor({}).useLatestSeasonDate).toBe(true);
     expect(
-      seasonFallbackModeFor({
-        enableMaintainerrSeasonOverlays: true,
+      seasonFallbackFor({ requireAllSeasonsLeaving: true }).useLatestSeasonDate
+    ).toBe(true);
+  });
+
+  it('honours an explicit earliest', () => {
+    expect(
+      seasonFallbackFor({
         requireAllSeasonsLeaving: true,
+        useLatestSeasonDate: false,
       })
-    ).toBe('all');
-  });
-
-  it('is off for a config predating both columns', () => {
-    expect(seasonFallbackModeFor({})).toBe('off');
+    ).toEqual({ mode: 'all', useLatestSeasonDate: false });
   });
 });
 

--- a/server/lib/overlays/maintainerrCountdown.test.ts
+++ b/server/lib/overlays/maintainerrCountdown.test.ts
@@ -7,6 +7,7 @@ import {
   collectSeasonCandidateKeys,
   computeDaysUntilAction,
   hasDeletionSchedule,
+  seasonFallbackModeFor,
 } from './maintainerrCountdown';
 
 /**
@@ -161,6 +162,379 @@ describe('computeDaysUntilAction', () => {
       media: [makeMedia({ mediaServerId: '25417', addDate: 'not-a-date' })],
     });
     expect(computeDaysUntilAction([collection], '25417')).toBeNull();
+  });
+});
+
+/**
+ * The show-level fallback: a show whose own ratingKey is in no collection
+ * inheriting a countdown from its seasons, which Maintainerr only exposes via the
+ * parent series' tmdbId on each season row.
+ *
+ * What makes this worth locking down is that the modes disagree on purpose. `'any'`
+ * says "a season is going" and dates the poster by the first departure; `'all'`
+ * says "the show is going" and will not commit unless it can prove every season is
+ * scheduled, dating the poster by the last one. Every unprovable case in `'all'` -
+ * a season staying, a row it cannot attribute to a season, a count that does not
+ * line up with Plex - has to come back null, because a wrong date here tells a user
+ * a show is leaving when it is not.
+ */
+describe('computeDaysUntilAction show-level season fallback', () => {
+  const SHOW_KEY = 'show-1';
+  const SEASON_1 = { mediaServerId: 'season-1' };
+  // Added 10 days later than the default, so at a given deleteAfterDays it has 10
+  // more days left - it is the season that goes LAST.
+  const SEASON_2 = {
+    mediaServerId: 'season-2',
+    addDate: '2026-01-11T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function forShow(
+    seasonFallback: 'off' | 'any' | 'all',
+    totalSeasons?: number
+  ) {
+    return { mediaType: 'show', tmdbId: 100, seasonFallback, totalSeasons };
+  }
+
+  it("takes nothing from the seasons in 'off' mode", () => {
+    const collection = makeCollection({
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('off'))
+    ).toBeNull();
+  });
+
+  it('defaults to off when the caller names no mode', () => {
+    const collection = makeCollection({ media: [makeMedia(SEASON_1)] });
+
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, {
+        mediaType: 'show',
+        tmdbId: 100,
+      })
+    ).toBeNull();
+  });
+
+  it("'any' takes the soonest season's date", () => {
+    const sooner = makeCollection({
+      id: 1,
+      title: 'Sooner',
+      deleteAfterDays: 35, // season 1 => 5
+      media: [makeMedia(SEASON_1)],
+    });
+    const later = makeCollection({
+      id: 2,
+      title: 'Later',
+      deleteAfterDays: 45, // season 1 => 15, season 2 => 25
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    const result = computeDaysUntilAction(
+      [later, sooner],
+      SHOW_KEY,
+      forShow('any')
+    );
+    expect(result?.days).toBe(5);
+    expect(result?.collection.title).toBe('Sooner');
+    // Two seasons are leaving, across three matched rows.
+    expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' dates the show by the season that leaves LAST", () => {
+    const collection = makeCollection({
+      deleteAfterDays: 45, // season 1 => 15, season 2 => 25
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    const result = computeDaysUntilAction(
+      [collection],
+      SHOW_KEY,
+      forShow('all', 2)
+    );
+    expect(result?.days).toBe(25);
+    expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' takes each season's soonest collection, then the latest of those", () => {
+    const slow = makeCollection({
+      id: 1,
+      title: 'Slow',
+      deleteAfterDays: 45, // season 1 => 15, season 2 => 25
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+    const fast = makeCollection({
+      id: 2,
+      title: 'Fast',
+      deleteAfterDays: 30, // season 2 => 10
+      media: [makeMedia(SEASON_2)],
+    });
+
+    // Season 2 leaves in 10 (Fast beats Slow's 25), season 1 in 15, so the show
+    // goes in 15. Summing rows or skipping the per-season minimum gives 25.
+    const result = computeDaysUntilAction(
+      [slow, fast],
+      SHOW_KEY,
+      forShow('all', 2)
+    );
+    expect(result?.days).toBe(15);
+    expect(result?.collection.title).toBe('Slow');
+    expect(result?.childItemsMatched).toBe(2);
+  });
+
+  it("'all' stays silent while one season is unscheduled", () => {
+    // Plex says three seasons; Maintainerr is tracking two, so the third - a
+    // numbered season or the Specials folder - keeps the show in the library.
+    const collection = makeCollection({
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('all', 3))
+    ).toBeNull();
+  });
+
+  it("'all' counts Specials as one of the seasons that must be leaving", () => {
+    // childCount includes season 0, so the denominator only balances once the
+    // Specials folder is scheduled too.
+    const collection = makeCollection({
+      deleteAfterDays: 45, // specials and season 1 => 15, season 2 => 25
+      media: [
+        makeMedia({ mediaServerId: 'season-0' }),
+        makeMedia(SEASON_1),
+        makeMedia(SEASON_2),
+      ],
+    });
+
+    const result = computeDaysUntilAction(
+      [collection],
+      SHOW_KEY,
+      forShow('all', 3)
+    );
+    expect(result?.days).toBe(25);
+    expect(result?.childItemsMatched).toBe(3);
+  });
+
+  it("'all' stays silent when a matched row carries no key", () => {
+    const collection = makeCollection({
+      media: [
+        makeMedia(SEASON_1),
+        makeMedia({ mediaServerId: undefined, plexId: undefined }),
+      ],
+    });
+
+    // The unidentifiable row may or may not be the second season - unprovable.
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('all', 2))
+    ).toBeNull();
+  });
+
+  it("'all' stays silent when the seasons outnumber Plex's childCount", () => {
+    const collection = makeCollection({
+      media: [
+        makeMedia(SEASON_1),
+        makeMedia(SEASON_2),
+        // A stale row, or this show in a second library. Either way the join is
+        // no longer describing the two seasons in front of us.
+        makeMedia({ mediaServerId: 'season-stale' }),
+      ],
+    });
+
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('all', 2))
+    ).toBeNull();
+  });
+
+  it("'all' stays silent when Plex reported no childCount", () => {
+    const collection = makeCollection({
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, forShow('all'))
+    ).toBeNull();
+  });
+
+  it("'all' ignores episode-type collections", () => {
+    const seasons = makeCollection({
+      id: 1,
+      title: 'Seasons',
+      type: 'season',
+      deleteAfterDays: 45, // season 1 => 15
+      media: [makeMedia(SEASON_1)],
+    });
+    const episodes = makeCollection({
+      id: 2,
+      title: 'Episodes',
+      type: 'episode',
+      deleteAfterDays: 35, // would be 5, and would add two more "seasons"
+      media: [
+        makeMedia({ mediaServerId: 'episode-1' }),
+        makeMedia({ mediaServerId: 'episode-2' }),
+      ],
+    });
+
+    const result = computeDaysUntilAction(
+      [seasons, episodes],
+      SHOW_KEY,
+      forShow('all', 1)
+    );
+    expect(result?.days).toBe(15);
+    expect(result?.collection.title).toBe('Seasons');
+    expect(result?.childItemsMatched).toBe(1);
+  });
+
+  it.each(['off', 'any', 'all'] as const)(
+    'a direct show ratingKey match wins in %s mode',
+    (mode) => {
+      const showLevel = makeCollection({
+        id: 1,
+        title: 'Show Level',
+        type: 'show',
+        deleteAfterDays: 40, // => 10
+        media: [makeMedia({ mediaServerId: SHOW_KEY })],
+      });
+      const seasonLevel = makeCollection({
+        id: 2,
+        title: 'Season Level',
+        type: 'season',
+        deleteAfterDays: 35, // => 5, and would be the whole show under 'all'
+        media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+      });
+
+      const result = computeDaysUntilAction(
+        [seasonLevel, showLevel],
+        SHOW_KEY,
+        forShow(mode, 2)
+      );
+      expect(result?.days).toBe(10);
+      expect(result?.collection.title).toBe('Show Level');
+      expect(result?.childItemsMatched).toBe(0);
+    }
+  );
+
+  it.each(['any', 'all'] as const)(
+    'a direct match with an unreadable date blocks the fallback in %s mode',
+    (mode) => {
+      const showLevel = makeCollection({
+        id: 1,
+        title: 'Show Level',
+        type: 'show',
+        media: [makeMedia({ mediaServerId: SHOW_KEY, addDate: 'not-a-date' })],
+      });
+      const seasonLevel = makeCollection({
+        id: 2,
+        title: 'Season Level',
+        deleteAfterDays: 35,
+        media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+      });
+
+      // The show has a schedule of its own; we just cannot read its date. A
+      // season's date would be describing a different event entirely.
+      expect(
+        computeDaysUntilAction(
+          [seasonLevel, showLevel],
+          SHOW_KEY,
+          forShow(mode, 2)
+        )
+      ).toBeNull();
+    }
+  );
+
+  it('a readable direct match still wins alongside an unreadable one', () => {
+    const unreadable = makeCollection({
+      id: 1,
+      title: 'Unreadable',
+      type: 'show',
+      deleteAfterDays: 20,
+      media: [makeMedia({ mediaServerId: SHOW_KEY, addDate: 'not-a-date' })],
+    });
+    const readable = makeCollection({
+      id: 2,
+      title: 'Readable',
+      type: 'show',
+      deleteAfterDays: 40, // => 10
+      media: [makeMedia({ mediaServerId: SHOW_KEY })],
+    });
+    const seasonLevel = makeCollection({
+      id: 3,
+      deleteAfterDays: 35, // => 5, and would win under 'any'
+      media: [makeMedia(SEASON_1), makeMedia(SEASON_2)],
+    });
+
+    const result = computeDaysUntilAction(
+      [unreadable, readable, seasonLevel],
+      SHOW_KEY,
+      forShow('any')
+    );
+    expect(result?.days).toBe(10);
+    expect(result?.collection.title).toBe('Readable');
+    expect(result?.childItemsMatched).toBe(0);
+  });
+
+  it('never falls back for a movie, whatever the mode says', () => {
+    const collection = makeCollection({ media: [makeMedia(SEASON_1)] });
+
+    expect(
+      computeDaysUntilAction([collection], SHOW_KEY, {
+        mediaType: 'movie',
+        tmdbId: 100,
+        seasonFallback: 'any',
+      })
+    ).toBeNull();
+  });
+});
+
+/**
+ * The parent toggle gates the fallback and the sub-toggle only narrows it, so a
+ * stored `requireAllSeasonsLeaving` must stay inert while the parent is off rather
+ * than turning the fallback back on.
+ */
+describe('seasonFallbackModeFor', () => {
+  it.each([
+    [false, false],
+    [false, true],
+  ])(
+    'is off while the season countdown is off (sub-toggle %s/%s)',
+    (enableMaintainerrSeasonOverlays, requireAllSeasonsLeaving) => {
+      expect(
+        seasonFallbackModeFor({
+          enableMaintainerrSeasonOverlays,
+          requireAllSeasonsLeaving,
+        })
+      ).toBe('off');
+    }
+  );
+
+  it('is any with the season countdown on and the sub-toggle off', () => {
+    expect(
+      seasonFallbackModeFor({
+        enableMaintainerrSeasonOverlays: true,
+        requireAllSeasonsLeaving: false,
+      })
+    ).toBe('any');
+  });
+
+  it('is all with both on', () => {
+    expect(
+      seasonFallbackModeFor({
+        enableMaintainerrSeasonOverlays: true,
+        requireAllSeasonsLeaving: true,
+      })
+    ).toBe('all');
+  });
+
+  it('is off for a config predating both columns', () => {
+    expect(seasonFallbackModeFor({})).toBe('off');
   });
 });
 

--- a/server/lib/overlays/maintainerrCountdown.ts
+++ b/server/lib/overlays/maintainerrCountdown.ts
@@ -1,17 +1,51 @@
-import type { MaintainerrCollection } from '@server/api/maintainerr';
+import type {
+  MaintainerrCollection,
+  MaintainerrMedia,
+} from '@server/api/maintainerr';
 
 /**
  * Result of a Maintainerr deletion-countdown lookup for a single Plex ratingKey:
  * how many days until Maintainerr acts on the item, and the collection that
- * yielded the soonest action.
+ * yielded the selected action.
  */
 export interface MaintainerrCountdown {
   /** deleteAfterDays minus days-since-added. Positive = remaining, negative = overdue. */
   days: number;
-  /** The collection with the LOWEST daysUntilAction for this item. */
+  /** The collection whose schedule produced `days`. */
   collection: MaintainerrCollection;
-  /** Season/episode members matched via the tmdbId fallback (0 for direct ratingKey hits). */
+  /** Distinct child items matched via the tmdbId fallback (0 for direct ratingKey hits). */
   childItemsMatched: number;
+}
+
+/**
+ * How a show poster may inherit a countdown from its seasons, when the show's own
+ * ratingKey is in no collection.
+ *
+ * - `'off'` - never. The library's "Season deletion countdown" toggle is off, so a
+ *   season leaving is a season's business and the show poster stays clean.
+ * - `'any'` - one leaving season is enough, and the show shows the SOONEST season's
+ *   date. Every collection type contributes, matching the pre-sub-toggle behaviour.
+ * - `'all'` - the show only gets a countdown once every one of its seasons is
+ *   scheduled, and it shows the LAST one to go, i.e. the day the show itself
+ *   disappears from Plex. Season-typed collections only.
+ */
+export type SeasonFallbackMode = 'off' | 'any' | 'all';
+
+/**
+ * Read a library's two season-countdown toggles as a single mode.
+ *
+ * Every caller that builds a show's render context goes through here, so the
+ * parent toggle gates the show-level fallback in exactly one place and the
+ * sub-toggle cannot be honoured on one code path and ignored on another.
+ */
+export function seasonFallbackModeFor(config: {
+  enableMaintainerrSeasonOverlays?: boolean;
+  requireAllSeasonsLeaving?: boolean;
+}): SeasonFallbackMode {
+  if (!config.enableMaintainerrSeasonOverlays) {
+    return 'off';
+  }
+  return config.requireAllSeasonsLeaving ? 'all' : 'any';
 }
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
@@ -88,7 +122,7 @@ export function collectSeasonCandidateKeys(
 
     seasonCollections++;
     for (const media of collection.media) {
-      const key = media.mediaServerId || media.plexId?.toString();
+      const key = mediaKey(media);
       if (key) {
         keys.add(key);
       } else {
@@ -98,6 +132,29 @@ export function collectSeasonCandidateKeys(
   }
 
   return { keys, seasonCollections, legacyTypedCollections, mediaWithoutKey };
+}
+
+/**
+ * `deleteAfterDays - daysSinceAdded` for one media row, or null when its `addDate`
+ * will not parse. Callers drop a null rather than letting it become a NaN
+ * countdown that renders as "leaving in NaN days".
+ */
+function rowDays(
+  collection: MaintainerrCollection,
+  media: MaintainerrMedia
+): number | null {
+  const addedTime = new Date(media.addDate).getTime();
+  if (Number.isNaN(addedTime)) {
+    return null;
+  }
+
+  const daysSinceAdded = Math.floor((Date.now() - addedTime) / MS_PER_DAY);
+  return collection.deleteAfterDays - daysSinceAdded;
+}
+
+/** The Plex ratingKey a media row points at (v3 `mediaServerId`, v2 `plexId`). */
+function mediaKey(media: MaintainerrMedia): string | undefined {
+  return media.mediaServerId || media.plexId?.toString();
 }
 
 /**
@@ -113,6 +170,17 @@ export function collectSeasonCandidateKeys(
  * never surface as a NaN countdown. Returns null when the item is in no
  * collection with a countdown.
  *
+ * A show whose own ratingKey is in no collection may still inherit a countdown
+ * from its seasons: Maintainerr stamps season rows with the parent series'
+ * tmdbId, which is the only join available. `opts.seasonFallback` decides whether
+ * and how (see `SeasonFallbackMode`); it defaults to `'off'`, so a caller that
+ * has not consulted the library toggle cannot leak a season's date onto a show.
+ * A direct ratingKey hit always wins outright: the show has its own schedule and
+ * what its seasons are doing is beside the point. That holds even when the hit
+ * yields no usable date. A show Maintainerr is scheduling by an unreadable
+ * `addDate` gets no countdown at all, rather than quietly falling through to a
+ * season's date that describes something else.
+ *
  * This is the single source of truth for the countdown: `buildRenderContext`
  * calls it to set `context.daysUntilAction`, and the season subpass calls it to
  * decide which seasons are still "active" — the render predicate and the
@@ -121,41 +189,97 @@ export function collectSeasonCandidateKeys(
 export function computeDaysUntilAction(
   collections: MaintainerrCollection[],
   ratingKey: string,
-  opts?: { mediaType?: string; tmdbId?: number }
+  opts?: {
+    mediaType?: string;
+    tmdbId?: number;
+    seasonFallback?: SeasonFallbackMode;
+    /** The show's Plex `childCount`. Required by `'all'`, ignored otherwise. */
+    totalSeasons?: number;
+  }
 ): MaintainerrCountdown | null {
-  const matches: { collection: MaintainerrCollection; days: number }[] = [];
-  let childItemsMatched = 0;
+  const direct: { collection: MaintainerrCollection; days: number }[] = [];
+  // Tracked separately from `direct`, which only holds rows that produced a
+  // date: the fallback is barred by the EXISTENCE of a schedule for this item,
+  // not by our success in reading it.
+  let directMatched = false;
 
   for (const collection of collections) {
     if (!hasDeletionSchedule(collection)) {
       continue;
     }
 
-    let mediaItems = collection.media.filter((m) => {
-      const id = m.mediaServerId || m.plexId?.toString();
-      return id === ratingKey;
-    });
-
-    // Fallback for season/episode-scoped Maintainerr collections: their members
-    // carry season ratingKeys that never equal the show's ratingKey. Maintainerr
-    // reports the parent series' tmdbId on those rows, so match by that instead.
-    if (mediaItems.length === 0 && opts?.mediaType === 'show' && opts?.tmdbId) {
-      const tid = opts.tmdbId;
-      mediaItems = collection.media.filter((m) => Number(m.tmdbId) === tid);
-      childItemsMatched += mediaItems.length;
-    }
-
-    for (const mediaItem of mediaItems) {
-      const addedTime = new Date(mediaItem.addDate).getTime();
-      if (Number.isNaN(addedTime)) {
+    for (const media of collection.media) {
+      if (mediaKey(media) !== ratingKey) {
         continue;
       }
 
-      const daysSinceAdded = Math.floor((Date.now() - addedTime) / MS_PER_DAY);
-      matches.push({
-        collection,
-        days: collection.deleteAfterDays - daysSinceAdded,
-      });
+      directMatched = true;
+      const days = rowDays(collection, media);
+      if (days !== null) {
+        direct.push({ collection, days });
+      }
+    }
+  }
+
+  if (directMatched) {
+    if (direct.length === 0) {
+      return null;
+    }
+
+    // Item may be in multiple collections; the one acting soonest wins.
+    const best = direct.reduce((min, curr) =>
+      curr.days < min.days ? curr : min
+    );
+    return { ...best, childItemsMatched: 0 };
+  }
+
+  const mode = opts?.seasonFallback ?? 'off';
+  if (mode === 'off' || opts?.mediaType !== 'show' || !opts?.tmdbId) {
+    return null;
+  }
+
+  return mode === 'all'
+    ? allSeasonsCountdown(collections, opts.tmdbId, opts.totalSeasons)
+    : anySeasonCountdown(collections, opts.tmdbId);
+}
+
+/**
+ * `'any'` fallback: the soonest date among every row Maintainerr tags with this
+ * show's tmdbId, across all collection types (episode-typed collections included,
+ * as they were before the sub-toggle existed).
+ *
+ * `childItemsMatched` counts DISTINCT keys rather than rows, so a season sitting
+ * in two collections is one departing season, not two. Rows Maintainerr sent
+ * without a key still drive the date but cannot be counted, since they are
+ * indistinguishable from each other.
+ */
+function anySeasonCountdown(
+  collections: MaintainerrCollection[],
+  tmdbId: number
+): MaintainerrCountdown | null {
+  const matches: { collection: MaintainerrCollection; days: number }[] = [];
+  const childKeys = new Set<string>();
+
+  for (const collection of collections) {
+    if (!hasDeletionSchedule(collection)) {
+      continue;
+    }
+
+    for (const media of collection.media) {
+      if (Number(media.tmdbId) !== tmdbId) {
+        continue;
+      }
+
+      const days = rowDays(collection, media);
+      if (days === null) {
+        continue;
+      }
+
+      matches.push({ collection, days });
+      const key = mediaKey(media);
+      if (key) {
+        childKeys.add(key);
+      }
     }
   }
 
@@ -163,9 +287,76 @@ export function computeDaysUntilAction(
     return null;
   }
 
-  // Item may be in multiple collections; the one acting soonest wins.
   const best = matches.reduce((min, curr) =>
     curr.days < min.days ? curr : min
   );
-  return { ...best, childItemsMatched };
+  return { ...best, childItemsMatched: childKeys.size };
+}
+
+/**
+ * `'all'` fallback: a countdown only when EVERY season of the show is scheduled,
+ * dated by the last one to leave. That is the day the show's listing disappears
+ * from Plex rather than the day it gets shorter.
+ *
+ * Only season-typed collections count (same filter as `collectSeasonCandidateKeys`);
+ * an episode-typed collection says nothing about whether a season is going.
+ * Within a season the soonest collection wins, exactly as for a directly matched
+ * item; across seasons the latest of those wins.
+ *
+ * Anything that stops us PROVING every season is leaving returns null rather than
+ * a guess: no `totalSeasons` (Plex gave no `childCount`), a matched row with no
+ * ratingKey to identify its season, or a distinct-season count that misses
+ * `totalSeasons` in either direction. Short means a season is staying; long means
+ * rows we cannot attribute (a stale season, another library's copy of the show)
+ * inflated the join.
+ */
+function allSeasonsCountdown(
+  collections: MaintainerrCollection[],
+  tmdbId: number,
+  totalSeasons: number | undefined
+): MaintainerrCountdown | null {
+  if (!totalSeasons || totalSeasons <= 0) {
+    return null;
+  }
+
+  const bySeason = new Map<
+    string,
+    { collection: MaintainerrCollection; days: number }
+  >();
+
+  for (const collection of collections) {
+    if (collection.type !== 'season' || !hasDeletionSchedule(collection)) {
+      continue;
+    }
+
+    for (const media of collection.media) {
+      if (Number(media.tmdbId) !== tmdbId) {
+        continue;
+      }
+
+      const key = mediaKey(media);
+      if (!key) {
+        return null;
+      }
+
+      const days = rowDays(collection, media);
+      if (days === null) {
+        continue;
+      }
+
+      const soonest = bySeason.get(key);
+      if (!soonest || days < soonest.days) {
+        bySeason.set(key, { collection, days });
+      }
+    }
+  }
+
+  if (bySeason.size !== totalSeasons) {
+    return null;
+  }
+
+  const last = [...bySeason.values()].reduce((max, curr) =>
+    curr.days > max.days ? curr : max
+  );
+  return { ...last, childItemsMatched: bySeason.size };
 }

--- a/server/lib/overlays/maintainerrCountdown.ts
+++ b/server/lib/overlays/maintainerrCountdown.ts
@@ -21,31 +21,57 @@ export interface MaintainerrCountdown {
  * How a show poster may inherit a countdown from its seasons, when the show's own
  * ratingKey is in no collection.
  *
- * - `'off'` - never. The library's "Season deletion countdown" toggle is off, so a
- *   season leaving is a season's business and the show poster stays clean.
+ * - `'off'` - never. Not a user setting: it is what a caller with no library config
+ *   to read names, so a code path that never consulted the library cannot put a
+ *   season's deletion date on a show poster.
  * - `'any'` - one leaving season is enough, and the show shows the SOONEST season's
- *   date. Every collection type contributes, matching the pre-sub-toggle behaviour.
+ *   date. Every collection type contributes. This is the default a library gets.
  * - `'all'` - the show only gets a countdown once every one of its seasons is
- *   scheduled, and it shows the LAST one to go, i.e. the day the show itself
- *   disappears from Plex. Season-typed collections only.
+ *   scheduled, dated by the last or the first season to go (see `SeasonFallback`).
+ *   Season-typed collections only.
  */
 export type SeasonFallbackMode = 'off' | 'any' | 'all';
 
 /**
- * Read a library's two season-countdown toggles as a single mode.
+ * The mode plus the date it picks. They travel together because a mode alone
+ * cannot be acted on: 'all' has to know which end of the departure window the
+ * show poster is dated by, and separating them lets a caller thread one and
+ * forget the other.
+ */
+export interface SeasonFallback {
+  mode: SeasonFallbackMode;
+  /** Under 'all': date the show by the LAST season to go, not the first. */
+  useLatestSeasonDate: boolean;
+}
+
+/** The fallback a caller with no library config may use: none. */
+export const NO_SEASON_FALLBACK: SeasonFallback = {
+  mode: 'off',
+  useLatestSeasonDate: true,
+};
+
+/**
+ * Read a library's "Show poster countdown" dropdown as a `SeasonFallback`.
+ *
+ * One setting, not two: the "Season deletion countdown" toggle gates the
+ * season-poster subpass and departed-season cleanup only. A user who wants the
+ * show poster marked without season posters being touched must be able to have
+ * that, so the show-level fallback answers to its own control.
  *
  * Every caller that builds a show's render context goes through here, so the
- * parent toggle gates the show-level fallback in exactly one place and the
- * sub-toggle cannot be honoured on one code path and ignored on another.
+ * dropdown cannot be honoured on one code path and ignored on another. An unset
+ * config reads as 'any' with the latest date, which is the dropdown's default.
  */
-export function seasonFallbackModeFor(config: {
-  enableMaintainerrSeasonOverlays?: boolean;
+export function seasonFallbackFor(config: {
   requireAllSeasonsLeaving?: boolean;
-}): SeasonFallbackMode {
-  if (!config.enableMaintainerrSeasonOverlays) {
-    return 'off';
-  }
-  return config.requireAllSeasonsLeaving ? 'all' : 'any';
+  useLatestSeasonDate?: boolean;
+}): SeasonFallback {
+  return {
+    mode: config.requireAllSeasonsLeaving ? 'all' : 'any',
+    // The column defaults to true, so an absent value means "not stored yet"
+    // (a row read before the migration ran), never "earliest".
+    useLatestSeasonDate: config.useLatestSeasonDate ?? true,
+  };
 }
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
@@ -174,7 +200,7 @@ function mediaKey(media: MaintainerrMedia): string | undefined {
  * from its seasons: Maintainerr stamps season rows with the parent series'
  * tmdbId, which is the only join available. `opts.seasonFallback` decides whether
  * and how (see `SeasonFallbackMode`); it defaults to `'off'`, so a caller that
- * has not consulted the library toggle cannot leak a season's date onto a show.
+ * has not consulted the library config cannot leak a season's date onto a show.
  * A direct ratingKey hit always wins outright: the show has its own schedule and
  * what its seasons are doing is beside the point. That holds even when the hit
  * yields no usable date. A show Maintainerr is scheduling by an unreadable
@@ -192,7 +218,7 @@ export function computeDaysUntilAction(
   opts?: {
     mediaType?: string;
     tmdbId?: number;
-    seasonFallback?: SeasonFallbackMode;
+    seasonFallback?: SeasonFallback;
     /** The show's Plex `childCount`. Required by `'all'`, ignored otherwise. */
     totalSeasons?: number;
   }
@@ -233,13 +259,18 @@ export function computeDaysUntilAction(
     return { ...best, childItemsMatched: 0 };
   }
 
-  const mode = opts?.seasonFallback ?? 'off';
-  if (mode === 'off' || opts?.mediaType !== 'show' || !opts?.tmdbId) {
+  const fallback = opts?.seasonFallback ?? NO_SEASON_FALLBACK;
+  if (fallback.mode === 'off' || opts?.mediaType !== 'show' || !opts?.tmdbId) {
     return null;
   }
 
-  return mode === 'all'
-    ? allSeasonsCountdown(collections, opts.tmdbId, opts.totalSeasons)
+  return fallback.mode === 'all'
+    ? allSeasonsCountdown(
+        collections,
+        opts.tmdbId,
+        opts.totalSeasons,
+        fallback.useLatestSeasonDate
+      )
     : anySeasonCountdown(collections, opts.tmdbId);
 }
 
@@ -248,10 +279,12 @@ export function computeDaysUntilAction(
  * show's tmdbId, across all collection types (episode-typed collections included,
  * as they were before the sub-toggle existed).
  *
- * `childItemsMatched` counts DISTINCT keys rather than rows, so a season sitting
- * in two collections is one departing season, not two. Rows Maintainerr sent
- * without a key still drive the date but cannot be counted, since they are
- * indistinguishable from each other.
+ * `childItemsMatched` counts DISTINCT keys from season-typed collections only,
+ * so a season sitting in two collections is one departing season, not two, and
+ * an episode row never masquerades as a season (`seasonsLeavingCount` is named
+ * for what it counts). Episode rows still drive the date; so do rows Maintainerr
+ * sent without a key, which cannot be counted because they are indistinguishable
+ * from each other.
  */
 function anySeasonCountdown(
   collections: MaintainerrCollection[],
@@ -277,7 +310,7 @@ function anySeasonCountdown(
 
       matches.push({ collection, days });
       const key = mediaKey(media);
-      if (key) {
+      if (key && collection.type === 'season') {
         childKeys.add(key);
       }
     }
@@ -294,14 +327,16 @@ function anySeasonCountdown(
 }
 
 /**
- * `'all'` fallback: a countdown only when EVERY season of the show is scheduled,
- * dated by the last one to leave. That is the day the show's listing disappears
- * from Plex rather than the day it gets shorter.
+ * `'all'` fallback: a countdown only when EVERY season of the show is scheduled.
+ * `useLatestSeasonDate` picks which end of the departure window the show is dated
+ * by - the last season to leave (the day the show's listing disappears from Plex)
+ * or the first (the day it starts getting shorter). Both answer real questions, so
+ * the library chooses.
  *
  * Only season-typed collections count (same filter as `collectSeasonCandidateKeys`);
  * an episode-typed collection says nothing about whether a season is going.
  * Within a season the soonest collection wins, exactly as for a directly matched
- * item; across seasons the latest of those wins.
+ * item; across seasons the chosen end of those wins.
  *
  * Anything that stops us PROVING every season is leaving returns null rather than
  * a guess: no `totalSeasons` (Plex gave no `childCount`), a matched row with no
@@ -313,7 +348,8 @@ function anySeasonCountdown(
 function allSeasonsCountdown(
   collections: MaintainerrCollection[],
   tmdbId: number,
-  totalSeasons: number | undefined
+  totalSeasons: number | undefined,
+  useLatestSeasonDate: boolean
 ): MaintainerrCountdown | null {
   if (!totalSeasons || totalSeasons <= 0) {
     return null;
@@ -355,8 +391,13 @@ function allSeasonsCountdown(
     return null;
   }
 
-  const last = [...bySeason.values()].reduce((max, curr) =>
-    curr.days > max.days ? curr : max
-  );
-  return { ...last, childItemsMatched: bySeason.size };
+  // Strict comparison in both directions, so a tie keeps the first season
+  // encountered rather than flipping with the direction.
+  const chosen = [...bySeason.values()].reduce((best, curr) => {
+    const beats = useLatestSeasonDate
+      ? curr.days > best.days
+      : curr.days < best.days;
+    return beats ? curr : best;
+  });
+  return { ...chosen, childItemsMatched: bySeason.size };
 }

--- a/server/migration/1787000000000-AddRequireAllSeasonsLeaving.ts
+++ b/server/migration/1787000000000-AddRequireAllSeasonsLeaving.ts
@@ -1,0 +1,35 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `requireAllSeasonsLeaving` on overlay_library_config: sub-toggle of
+ * `enableMaintainerrSeasonOverlays` (per show library) that holds a show poster's
+ * deletion countdown back until every one of its seasons is scheduled to leave,
+ * dating it by the last season to go. Defaults to 0, which keeps the existing
+ * behaviour where any leaving season puts its date on the show.
+ */
+export class AddRequireAllSeasonsLeaving1787000000000
+  implements MigrationInterface
+{
+  name = 'AddRequireAllSeasonsLeaving1787000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Guarded so the migration is safe to re-run if it ever partially applied.
+    // down() intentionally leaves the column, since SQLite can't cleanly drop
+    // it, so a revert+run would otherwise hit "duplicate column name".
+    const hasColumn = await queryRunner.hasColumn(
+      'overlay_library_config',
+      'requireAllSeasonsLeaving'
+    );
+    if (!hasColumn) {
+      await queryRunner.query(
+        `ALTER TABLE "overlay_library_config" ADD COLUMN "requireAllSeasonsLeaving" boolean NOT NULL DEFAULT 0`
+      );
+    }
+  }
+
+  public async down(): Promise<void> {
+    // SQLite doesn't support DROP COLUMN cleanly. The column has a default and
+    // is ignored by older code, so we leave it in place (mirrors
+    // AddMaintainerrSeasonOverlays1783000000000).
+  }
+}

--- a/server/migration/1788000000000-AddUseLatestSeasonDate.ts
+++ b/server/migration/1788000000000-AddUseLatestSeasonDate.ts
@@ -1,0 +1,33 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `useLatestSeasonDate` on overlay_library_config: when the "Show poster
+ * countdown" setting requires every season to be leaving, this picks which end of
+ * the departure window dates the show poster - the last season to go (the day the
+ * show disappears from Plex) or the first. Defaults to 1, the day the show is
+ * fully gone, which is the meaning the all-seasons rule shipped with.
+ */
+export class AddUseLatestSeasonDate1788000000000 implements MigrationInterface {
+  name = 'AddUseLatestSeasonDate1788000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Guarded so the migration is safe to re-run if it ever partially applied.
+    // down() intentionally leaves the column, since SQLite can't cleanly drop
+    // it, so a revert+run would otherwise hit "duplicate column name".
+    const hasColumn = await queryRunner.hasColumn(
+      'overlay_library_config',
+      'useLatestSeasonDate'
+    );
+    if (!hasColumn) {
+      await queryRunner.query(
+        `ALTER TABLE "overlay_library_config" ADD COLUMN "useLatestSeasonDate" boolean NOT NULL DEFAULT 1`
+      );
+    }
+  }
+
+  public async down(): Promise<void> {
+    // SQLite doesn't support DROP COLUMN cleanly. The column has a default and
+    // is ignored by older code, so we leave it in place (mirrors
+    // AddRequireAllSeasonsLeaving1787000000000).
+  }
+}

--- a/server/routes/overlayLibraryConfigs.ts
+++ b/server/routes/overlayLibraryConfigs.ts
@@ -163,6 +163,9 @@ router.post('/:libraryId', async (req, res, next) => {
         config.enableMaintainerrSeasonOverlays =
           !!req.body.enableMaintainerrSeasonOverlays;
       }
+      if ('requireAllSeasonsLeaving' in req.body) {
+        config.requireAllSeasonsLeaving = !!req.body.requireAllSeasonsLeaving;
+      }
     } else {
       // Create new
       config = new OverlayLibraryConfig({
@@ -174,6 +177,7 @@ router.post('/:libraryId', async (req, res, next) => {
         enableEpisodeScanning: !!req.body.enableEpisodeScanning,
         enableMaintainerrSeasonOverlays:
           !!req.body.enableMaintainerrSeasonOverlays,
+        requireAllSeasonsLeaving: !!req.body.requireAllSeasonsLeaving,
       });
     }
 

--- a/server/routes/overlayLibraryConfigs.ts
+++ b/server/routes/overlayLibraryConfigs.ts
@@ -166,6 +166,9 @@ router.post('/:libraryId', async (req, res, next) => {
       if ('requireAllSeasonsLeaving' in req.body) {
         config.requireAllSeasonsLeaving = !!req.body.requireAllSeasonsLeaving;
       }
+      if ('useLatestSeasonDate' in req.body) {
+        config.useLatestSeasonDate = !!req.body.useLatestSeasonDate;
+      }
     } else {
       // Create new
       config = new OverlayLibraryConfig({
@@ -178,6 +181,11 @@ router.post('/:libraryId', async (req, res, next) => {
         enableMaintainerrSeasonOverlays:
           !!req.body.enableMaintainerrSeasonOverlays,
         requireAllSeasonsLeaving: !!req.body.requireAllSeasonsLeaving,
+        // Defaults to true, so an absent field must not coerce to false.
+        useLatestSeasonDate:
+          'useLatestSeasonDate' in req.body
+            ? !!req.body.useLatestSeasonDate
+            : true,
       });
     }
 

--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -3,6 +3,7 @@ import PlexAPI from '@server/api/plexapi';
 import { getRepository } from '@server/datasource';
 import { OverlayLibraryConfig } from '@server/entity/OverlayLibraryConfig';
 import { OverlayTemplate } from '@server/entity/OverlayTemplate';
+import { seasonFallbackModeFor } from '@server/lib/overlays/maintainerrCountdown';
 import {
   buildRenderContext,
   checkMonitoringStatus,
@@ -211,7 +212,12 @@ overlayTestRouter.post('/', async (req, res) => {
       item,
       actualMediaType,
       isPlaceholder,
-      maintainerrCollections
+      maintainerrCollections,
+      undefined,
+      undefined,
+      // Same derivation as a real library run, so a test never shows a
+      // season-derived countdown the library itself would withhold.
+      seasonFallbackModeFor(config)
     );
 
     // For test endpoint, log warning but continue even if APIs failed

--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -3,7 +3,7 @@ import PlexAPI from '@server/api/plexapi';
 import { getRepository } from '@server/datasource';
 import { OverlayLibraryConfig } from '@server/entity/OverlayLibraryConfig';
 import { OverlayTemplate } from '@server/entity/OverlayTemplate';
-import { seasonFallbackModeFor } from '@server/lib/overlays/maintainerrCountdown';
+import { seasonFallbackFor } from '@server/lib/overlays/maintainerrCountdown';
 import {
   buildRenderContext,
   checkMonitoringStatus,
@@ -217,7 +217,7 @@ overlayTestRouter.post('/', async (req, res) => {
       undefined,
       // Same derivation as a real library run, so a test never shows a
       // season-derived countdown the library itself would withhold.
-      seasonFallbackModeFor(config)
+      seasonFallbackFor(config)
     );
 
     // For test endpoint, log warning but continue even if APIs failed

--- a/src/components/Posters/LibraryDetailConfigView.tsx
+++ b/src/components/Posters/LibraryDetailConfigView.tsx
@@ -183,6 +183,7 @@ interface LibraryConfig {
   tmdbLanguage?: string;
   enableEpisodeScanning?: boolean;
   enableMaintainerrSeasonOverlays?: boolean;
+  requireAllSeasonsLeaving?: boolean;
   maintainerrConfigured?: boolean;
 }
 
@@ -331,6 +332,8 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
   const [enableEpisodeScanning, setEnableEpisodeScanning] = useState(false);
   const [enableMaintainerrSeasonOverlays, setEnableMaintainerrSeasonOverlays] =
     useState(false);
+  const [requireAllSeasonsLeaving, setRequireAllSeasonsLeaving] =
+    useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const previewDebounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -390,6 +393,9 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
       setEnableMaintainerrSeasonOverlays(
         configData.enableMaintainerrSeasonOverlays
       );
+    }
+    if (configData?.requireAllSeasonsLeaving !== undefined) {
+      setRequireAllSeasonsLeaving(configData.requireAllSeasonsLeaving);
     }
     if (configData?.tmdbLanguage !== undefined) {
       setTmdbLanguage(configData.tmdbLanguage);
@@ -585,6 +591,7 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
             tmdbLanguage: tmdbLanguage || undefined,
             enableEpisodeScanning,
             enableMaintainerrSeasonOverlays,
+            requireAllSeasonsLeaving,
           }),
         }
       );
@@ -773,6 +780,36 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
                   )}
                 </div>
               </div>
+
+              {/* Sub-toggle: scopes the countdown the show poster inherits from
+                  its seasons. Meaningless while the parent is off, so hidden. */}
+              {enableMaintainerrSeasonOverlays && (
+                <div className="ml-12 mt-3 flex items-center gap-3">
+                  <label className="relative inline-flex cursor-pointer items-center">
+                    <input
+                      type="checkbox"
+                      checked={requireAllSeasonsLeaving}
+                      onChange={(e) =>
+                        setRequireAllSeasonsLeaving(e.target.checked)
+                      }
+                      className="peer sr-only"
+                    />
+                    <div className="peer h-5 w-9 rounded-full bg-stone-600 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:bg-indigo-500 peer-checked:after:translate-x-full" />
+                  </label>
+                  <div>
+                    <span className="text-sm font-medium text-white">
+                      Only overlay the show when every season is leaving
+                    </span>
+                    <p className="text-xs text-stone-400">
+                      The show poster only gets the countdown once all of its
+                      seasons are scheduled to leave, and it shows the date the
+                      last season goes. Leave this off to keep the current
+                      behavior: any leaving season puts its date on the show
+                      poster.
+                    </p>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/Posters/LibraryDetailConfigView.tsx
+++ b/src/components/Posters/LibraryDetailConfigView.tsx
@@ -184,6 +184,7 @@ interface LibraryConfig {
   enableEpisodeScanning?: boolean;
   enableMaintainerrSeasonOverlays?: boolean;
   requireAllSeasonsLeaving?: boolean;
+  useLatestSeasonDate?: boolean;
   maintainerrConfigured?: boolean;
 }
 
@@ -334,6 +335,7 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
     useState(false);
   const [requireAllSeasonsLeaving, setRequireAllSeasonsLeaving] =
     useState(false);
+  const [useLatestSeasonDate, setUseLatestSeasonDate] = useState(true);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const previewDebounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -396,6 +398,9 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
     }
     if (configData?.requireAllSeasonsLeaving !== undefined) {
       setRequireAllSeasonsLeaving(configData.requireAllSeasonsLeaving);
+    }
+    if (configData?.useLatestSeasonDate !== undefined) {
+      setUseLatestSeasonDate(configData.useLatestSeasonDate);
     }
     if (configData?.tmdbLanguage !== undefined) {
       setTmdbLanguage(configData.tmdbLanguage);
@@ -592,6 +597,7 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
             enableEpisodeScanning,
             enableMaintainerrSeasonOverlays,
             requireAllSeasonsLeaving,
+            useLatestSeasonDate,
           }),
         }
       );
@@ -607,6 +613,20 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
       alert(intl.formatMessage(messages.saveFailed));
     } finally {
       setSaving(false);
+    }
+  };
+
+  // Derived so the dropdown can never drift from the two stored booleans.
+  const showPosterCountdown = !requireAllSeasonsLeaving
+    ? 'any'
+    : useLatestSeasonDate
+    ? 'all-latest'
+    : 'all-earliest';
+
+  const handleShowPosterCountdownChange = (value: string) => {
+    setRequireAllSeasonsLeaving(value !== 'any');
+    if (value !== 'any') {
+      setUseLatestSeasonDate(value === 'all-latest');
     }
   };
 
@@ -733,6 +753,53 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
             </div>
           )}
 
+          {/* Show Poster Countdown Mode - Only for show libraries */}
+          {libraryType === 'show' && (
+            <div className="mt-4 border-t border-stone-700 pt-4">
+              <div className="flex items-center gap-4">
+                <label
+                  htmlFor="showPosterCountdown"
+                  className={`text-sm font-medium ${
+                    configData?.maintainerrConfigured
+                      ? 'text-white'
+                      : 'text-stone-400'
+                  }`}
+                >
+                  Show poster countdown
+                </label>
+                <select
+                  id="showPosterCountdown"
+                  value={showPosterCountdown}
+                  disabled={!configData?.maintainerrConfigured}
+                  onChange={(e) =>
+                    handleShowPosterCountdownChange(e.target.value)
+                  }
+                  className={`rounded-md border-stone-600 bg-stone-700 px-3 py-1.5 text-sm text-white ${
+                    configData?.maintainerrConfigured
+                      ? ''
+                      : 'cursor-not-allowed opacity-50'
+                  }`}
+                >
+                  <option value="any">Any season</option>
+                  <option value="all-earliest">All seasons (earliest)</option>
+                  <option value="all-latest">All seasons (latest)</option>
+                </select>
+              </div>
+              {!configData?.maintainerrConfigured && (
+                <p className="mt-1 text-xs text-amber-500">
+                  Connect Maintainerr in Settings to enable this.
+                </p>
+              )}
+              <p className="mt-1 text-xs text-stone-400">
+                When a show&apos;s seasons are in Maintainerr collections, this
+                decides when the show poster gets a countdown and which date it
+                shows. Any season shows the soonest date. All seasons only marks
+                a show once every season is scheduled to leave. A show directly
+                in a Maintainerr collection always uses its own date.
+              </p>
+            </div>
+          )}
+
           {/* Maintainerr Season Countdown Toggle - Only for show libraries */}
           {libraryType === 'show' && (
             <div className="mt-4 border-t border-stone-700 pt-4">
@@ -773,43 +840,8 @@ const LibraryDetailConfigView: React.FC<LibraryDetailConfigViewProps> = ({
                     Season collections trigger a full-library scan in
                     Maintainerr.
                   </p>
-                  {!configData?.maintainerrConfigured && (
-                    <p className="mt-1 text-xs text-amber-500">
-                      Connect Maintainerr in Settings to enable this.
-                    </p>
-                  )}
                 </div>
               </div>
-
-              {/* Sub-toggle: scopes the countdown the show poster inherits from
-                  its seasons. Meaningless while the parent is off, so hidden. */}
-              {enableMaintainerrSeasonOverlays && (
-                <div className="ml-12 mt-3 flex items-center gap-3">
-                  <label className="relative inline-flex cursor-pointer items-center">
-                    <input
-                      type="checkbox"
-                      checked={requireAllSeasonsLeaving}
-                      onChange={(e) =>
-                        setRequireAllSeasonsLeaving(e.target.checked)
-                      }
-                      className="peer sr-only"
-                    />
-                    <div className="peer h-5 w-9 rounded-full bg-stone-600 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:bg-indigo-500 peer-checked:after:translate-x-full" />
-                  </label>
-                  <div>
-                    <span className="text-sm font-medium text-white">
-                      Only overlay the show when every season is leaving
-                    </span>
-                    <p className="text-xs text-stone-400">
-                      The show poster only gets the countdown once all of its
-                      seasons are scheduled to leave, and it shows the date the
-                      last season goes. Leave this off to keep the current
-                      behavior: any leaving season puts its date on the show
-                      poster.
-                    </p>
-                  </div>
-                </div>
-              )}
             </div>
           )}
 


### PR DESCRIPTION
## Description

Right now a show poster gets a Maintainerr countdown as soon as any one of its seasons is leaving, and it shows the soonest date. So a show with one season leaving tomorrow reads "deleting in 1 day" even though the rest of it is staying.

This PR adds a "Show poster countdown" dropdown to each show library's overlay config, so you can pick what the show poster means:

- **Any season** (default): any leaving season marks the show, soonest date. This is the current behaviour, unchanged.
- **All seasons (earliest)**: the show is only marked once every season (specials included) is scheduled to leave, dated by when deletion starts.
- **All seasons (latest)**: same rule, dated by when the last season goes, i.e. when the show disappears from Plex entirely.

The all-seasons modes refuse to guess: if it can't be proven that every season is leaving (missing IDs, a season count that doesn't line up), the show gets no countdown that cycle. A show that's directly in a Maintainerr collection always uses its own date, and the existing "Season deletion countdown" toggle is untouched: it still controls season posters only.

Also fixes `seasonsLeavingCount`, which could count a season twice when it sat in two collections, and counted episode rows as seasons.

Migrations included for the two new columns.

## Screenshot (if UI-related)

### Settings
<img width="882" height="324" alt="image" src="https://github.com/user-attachments/assets/c85c6981-7417-4402-b021-274f68259532" />
<img width="694" height="128" alt="image" src="https://github.com/user-attachments/assets/7809bd9d-a3bb-4efb-9873-dc13a4ab261b" />


### Any season (Default)
<img width="506" height="446" alt="image" src="https://github.com/user-attachments/assets/a343ff64-4f4c-4fc5-9fb0-34a50229702a" />

### All Seasons (Earliest)
<img width="498" height="443" alt="image" src="https://github.com/user-attachments/assets/1f80ddfa-b169-47ab-8c00-d8f33995ec6c" />

### All Seasons (Latest)
<img width="497" height="448" alt="image" src="https://github.com/user-attachments/assets/1b01c607-eb78-4fc6-9fc7-1b54cb8842df" />

### All Seasons (Not fulfilled)
<img width="499" height="447" alt="image" src="https://github.com/user-attachments/assets/89c1274b-37c4-42c6-8699-4cb3b399ff69" />

## How Has This Been Tested?

Built and published to [DockerHub](https://hub.docker.com/r/rubeanie/agregarr) `rubeanie/agregarr:season-countdown`. Self-tested with Plex.

## Checklist

- [X] Type checking (`yarn typecheck`)
- [X] Build succeeds (`yarn build`)
- [X] Translation keys extracted (`yarn i18n:extract`) - the overlay config section is deliberately hardcoded, matching its neighbours
- [X] Database migration included - two, both guarded
- [X] Formatting (prettier) (`yarn format`)
- [X] Linting (`yarn lint`)
