### PR TITLE
Feat/dynamic title prefix

### DIFF
--- a/server/lib/collections/core/BaseCollectionSync.ts
+++ b/server/lib/collections/core/BaseCollectionSync.ts
@@ -495,7 +495,7 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
     // Handle special dynamic random title template
     if (config.template === 'DYNAMIC_RANDOM_TITLE') {
       // DYNAMIC_RANDOM_TITLE should be handled by each subclass in fetchSourceData
-      // Fall back to config.name if not handled
+      // Fall back to config.name (which may already include prefix from a previous sync)
       return config.name;
     }
 

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -246,15 +246,19 @@ export class MultiSourceOrchestrator {
 
         if (this.dynamicCycleTitle) {
           const previousName = config.name;
-          collectionNameForSync = this.dynamicCycleTitle;
+          const prefix = config.dynamicTitlePrefix || '';
+          const prefixedName = prefix
+            ? `${prefix} ${this.dynamicCycleTitle}`
+            : this.dynamicCycleTitle;
+          collectionNameForSync = prefixedName;
           configForSync = {
             ...configForSync,
-            name: this.dynamicCycleTitle,
+            name: prefixedName,
           } as MultiSourceCollectionConfig;
 
           // Persist updated name and source title for subsequent syncs
           this.updateCollectionConfigField(config.id, {
-            name: this.dynamicCycleTitle,
+            name: prefixedName,
           });
           this.updateSourceResolvedTitle(
             config.id,

--- a/server/lib/collections/sources/imdb.ts
+++ b/server/lib/collections/sources/imdb.ts
@@ -182,7 +182,9 @@ export class ImdbCollectionSync extends BaseCollectionSync<'imdb'> {
         // Store the dynamic title for use in generateCollectionNameWithCustom
         if (config.template === 'DYNAMIC_RANDOM_TITLE') {
           this.dynamicRandomTitle = listTitle;
-          this.updateCollectionConfigField(config.id, { name: listTitle });
+          const prefix = config.dynamicTitlePrefix || '';
+          const prefixedName = prefix ? `${prefix} ${listTitle}` : listTitle;
+          this.updateCollectionConfigField(config.id, { name: prefixedName });
         }
 
         logger.info(`Using random IMDb list: ${randomUrl}`, {
@@ -912,7 +914,10 @@ export class ImdbCollectionSync extends BaseCollectionSync<'imdb'> {
   ): Promise<string> {
     // Handle DYNAMIC_RANDOM_TITLE using stored title from fetchSourceData
     if (config.template === 'DYNAMIC_RANDOM_TITLE' && this.dynamicRandomTitle) {
-      return this.dynamicRandomTitle;
+      const prefix = config.dynamicTitlePrefix || '';
+      return prefix
+        ? `${prefix} ${this.dynamicRandomTitle}`
+        : this.dynamicRandomTitle;
     }
 
     // Fall back to base implementation for other templates

--- a/server/lib/collections/sources/letterboxd.ts
+++ b/server/lib/collections/sources/letterboxd.ts
@@ -116,7 +116,9 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
         // Store the dynamic title for use in generateCollectionNameWithCustom
         if (config.template === 'DYNAMIC_RANDOM_TITLE') {
           this.dynamicRandomTitle = listTitle;
-          this.updateCollectionConfigField(config.id, { name: listTitle });
+          const prefix = config.dynamicTitlePrefix || '';
+          const prefixedName = prefix ? `${prefix} ${listTitle}` : listTitle;
+          this.updateCollectionConfigField(config.id, { name: prefixedName });
         }
 
         logger.info(`Using random Letterboxd list: ${randomUrl}`, {
@@ -723,7 +725,10 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
   ): Promise<string> {
     // Handle DYNAMIC_RANDOM_TITLE using stored title from fetchSourceData
     if (config.template === 'DYNAMIC_RANDOM_TITLE' && this.dynamicRandomTitle) {
-      return this.dynamicRandomTitle;
+      const prefix = config.dynamicTitlePrefix || '';
+      return prefix
+        ? `${prefix} ${this.dynamicRandomTitle}`
+        : this.dynamicRandomTitle;
     }
 
     // Fall back to base implementation for other templates

--- a/server/lib/collections/sources/tmdb.ts
+++ b/server/lib/collections/sources/tmdb.ts
@@ -1117,7 +1117,9 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
         // Store the dynamic title for use in generateCollectionNameWithCustom
         if (config.template === 'DYNAMIC_RANDOM_TITLE') {
           this.dynamicRandomTitle = listTitle;
-          this.updateCollectionConfigField(config.id, { name: listTitle });
+          const prefix = config.dynamicTitlePrefix || '';
+          const prefixedName = prefix ? `${prefix} ${listTitle}` : listTitle;
+          this.updateCollectionConfigField(config.id, { name: prefixedName });
         }
 
         logger.info(`Using random TMDB collection: ${randomUrl}`, {
@@ -1277,7 +1279,10 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
   ): Promise<string> {
     // Handle DYNAMIC_RANDOM_TITLE using stored title from fetchSourceData
     if (config.template === 'DYNAMIC_RANDOM_TITLE' && this.dynamicRandomTitle) {
-      return this.dynamicRandomTitle;
+      const prefix = config.dynamicTitlePrefix || '';
+      return prefix
+        ? `${prefix} ${this.dynamicRandomTitle}`
+        : this.dynamicRandomTitle;
     }
 
     // Fall back to base implementation for other templates

--- a/server/lib/collections/sources/trakt.ts
+++ b/server/lib/collections/sources/trakt.ts
@@ -177,7 +177,10 @@ export class TraktCollectionSync extends BaseCollectionSync<'trakt'> {
   ): Promise<string> {
     // Handle DYNAMIC_RANDOM_TITLE using stored title from fetchSourceData
     if (config.template === 'DYNAMIC_RANDOM_TITLE' && this.dynamicRandomTitle) {
-      return this.dynamicRandomTitle;
+      const prefix = config.dynamicTitlePrefix || '';
+      return prefix
+        ? `${prefix} ${this.dynamicRandomTitle}`
+        : this.dynamicRandomTitle;
     }
 
     // Fall back to base implementation for other templates
@@ -466,7 +469,9 @@ export class TraktCollectionSync extends BaseCollectionSync<'trakt'> {
           // Store the dynamic title for use in generateCollectionNameWithCustom
           if (config.template === 'DYNAMIC_RANDOM_TITLE') {
             this.dynamicRandomTitle = listTitle;
-            this.updateCollectionConfigField(config.id, { name: listTitle });
+            const prefix = config.dynamicTitlePrefix || '';
+            const prefixedName = prefix ? `${prefix} ${listTitle}` : listTitle;
+            this.updateCollectionConfigField(config.id, { name: prefixedName });
           }
 
           logger.info(`Using random Trakt list: ${randomUrl}`, {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -2359,6 +2359,7 @@ export interface MultiSourceCollectionConfig {
   readonly libraryName: string;
   readonly maxItems?: number;
   readonly template?: string;
+  readonly dynamicTitlePrefix?: string; // Text to prepend to dynamic titles (DYNAMIC_RANDOM_TITLE / DYNAMIC_CYCLE_TITLE)
   readonly sources: readonly SourceDefinition[];
   readonly combineMode: MultiSourceCombineMode;
   readonly customSyncSchedule?: CustomSyncSchedule;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -93,6 +93,7 @@ export interface CollectionConfig {
   readonly template: string; // Collection template
   readonly customMovieTemplate?: string; // Custom template for movie collections when mediaType is 'both'
   readonly customTVTemplate?: string; // Custom template for TV collections when mediaType is 'both'
+  readonly dynamicTitlePrefix?: string; // Text to prepend to dynamic titles (DYNAMIC_RANDOM_TITLE / DYNAMIC_CYCLE_TITLE)
   readonly visibilityConfig: {
     usersHome: boolean;
     serverOwnerHome: boolean;

--- a/server/routes/collectionExportImport.ts
+++ b/server/routes/collectionExportImport.ts
@@ -35,6 +35,7 @@ const portableFields = [
   'template',
   'customMovieTemplate',
   'customTVTemplate',
+  'dynamicTitlePrefix',
   'visibilityConfig',
   'sortOrderHome',
   'sortOrderLibrary',

--- a/src/components/Collections/FormSections/TemplateSection.tsx
+++ b/src/components/Collections/FormSections/TemplateSection.tsx
@@ -138,6 +138,13 @@ const TemplateSection = ({
               setFieldValue('customMovieTemplate', '');
               setFieldValue('customTVTemplate', '');
             }
+            if (
+              e.target.value !== 'DYNAMIC_RANDOM_TITLE' &&
+              e.target.value !== 'DYNAMIC_CYCLE_TITLE'
+            ) {
+              // Clear dynamic title prefix when not using dynamic titles
+              setFieldValue('dynamicTitlePrefix', '');
+            }
           }}
         >
           {(() => {
@@ -165,6 +172,26 @@ const TemplateSection = ({
           })()}
         </Field>
       </div>
+
+      {/* Dynamic title prefix input */}
+      {(values.template === 'DYNAMIC_RANDOM_TITLE' ||
+        values.template === 'DYNAMIC_CYCLE_TITLE') && (
+        <div className="mt-2">
+          <div className="form-input-field">
+            <Field
+              type="text"
+              name="dynamicTitlePrefix"
+              placeholder="Title prefix (e.g. 🎬)"
+              onChange={handleChange}
+            />
+          </div>
+          <div className="label-tip">
+            This text will be prepended to the dynamic title. Example: if prefix
+            is &quot;🎬&quot; and the list title is &quot;Musical&quot;, the
+            collection will be named &quot;🎬 Musical&quot;.
+          </div>
+        </div>
+      )}
 
       {/* Custom template input */}
       {values.template === 'custom' && (

--- a/src/components/Collections/Views/CollectionSettings.tsx
+++ b/src/components/Collections/Views/CollectionSettings.tsx
@@ -398,6 +398,7 @@ const CollectionSettings = ({
           template: config.template,
           customMovieTemplate: config.customMovieTemplate,
           customTVTemplate: config.customTVTemplate,
+          dynamicTitlePrefix: config.dynamicTitlePrefix,
           visibilityConfig: config.visibilityConfig,
           maxItems: config.maxItems,
           mediaType: config.mediaType,
@@ -627,6 +628,7 @@ const CollectionSettings = ({
       template: '',
       customMovieTemplate: '', // Initialize empty custom movie template
       customTVTemplate: '', // Initialize empty custom TV template
+      dynamicTitlePrefix: '', // Initialize empty dynamic title prefix
       visibilityConfig: {
         usersHome: true,
         serverOwnerHome: true,

--- a/src/types/collections/index.ts
+++ b/src/types/collections/index.ts
@@ -207,6 +207,7 @@ export interface CollectionFormConfig {
   readonly template?: string; // Collection title template (for preset templates or single media type) - optional for hubs/pre-existing
   readonly customMovieTemplate?: string; // Custom template for movie collections when mediaType is 'both'
   readonly customTVTemplate?: string; // Custom template for TV collections when mediaType is 'both'
+  readonly dynamicTitlePrefix?: string; // Text to prepend to dynamic titles (DYNAMIC_RANDOM_TITLE / DYNAMIC_CYCLE_TITLE)
   readonly visibilityConfig: {
     usersHome: boolean;
     serverOwnerHome: boolean;
@@ -521,6 +522,7 @@ export interface CollectionConfigCreateRequest {
   readonly template?: string;
   readonly customMovieTemplate?: string;
   readonly customTVTemplate?: string;
+  readonly dynamicTitlePrefix?: string;
   readonly visibilityConfig: {
     usersHome: boolean;
     serverOwnerHome: boolean;
@@ -714,6 +716,7 @@ export const toCollectionCreateRequest = (
     template: config.template,
     customMovieTemplate: config.customMovieTemplate,
     customTVTemplate: config.customTVTemplate,
+    dynamicTitlePrefix: config.dynamicTitlePrefix,
     visibilityConfig: config.visibilityConfig,
     // Explicitly exclude isActive - backend computes this
     maxItems: config.maxItems,

--- a/src/utils/collections/apiHandlers.ts
+++ b/src/utils/collections/apiHandlers.ts
@@ -139,6 +139,9 @@ export const saveIndividualConfigs = async (
         ...(collectionConfig.customTVTemplate && {
           customTVTemplate: collectionConfig.customTVTemplate,
         }),
+        ...(collectionConfig.dynamicTitlePrefix !== undefined && {
+          dynamicTitlePrefix: collectionConfig.dynamicTitlePrefix,
+        }),
         visibilityConfig: collectionConfig.visibilityConfig,
         ...(collectionConfig.maxItems !== undefined && {
           maxItems: collectionConfig.maxItems,


### PR DESCRIPTION
#### Description

Allow users to prepend custom text (e.g. an emoji) to dynamic collection
titles. When a DYNAMIC_RANDOM_TITLE or DYNAMIC_CYCLE_TITLE template is
selected, a new "Title prefix" input appears in the UI. The prefix is
prepended to the resolved list title during sync.

#### Screenshot (if UI-related)

<img width="650" height="263" alt="image" src="https://github.com/user-attachments/assets/0ea804a1-187a-4b0f-83bb-db1cbb302f5f" />
